### PR TITLE
fix: prefix Cloud Build substitutions

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -52,7 +52,7 @@ echo "🔨 Building frontend UI..."
 cd ui
 gcloud builds submit \
   --tag $REGION-docker.pkg.dev/$PROJECT_ID/$REPO/ppa-ui:latest \
-  --substitutions=VITE_API_BASE=$API_URL
+  --substitutions=_REGION=$REGION,_REPO=$REPO,_VITE_API_BASE=$API_URL
 cd ..
 
 UI_IMG="$REGION-docker.pkg.dev/$PROJECT_ID/$REPO/ppa-ui:latest"


### PR DESCRIPTION
## Summary
- prefix UI build substitutions with underscores in ops/deploy.sh
- ensure Cloud Build uses `_VITE_API_BASE` for UI image build

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, forbidden require imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a376996f5c8330862f300ed295774f