### PR TITLE
fix: avoid duplicate toast listeners

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -172,6 +172,7 @@ function useToast() {
   const [state, setState] = React.useState<State>(memoryState)
 
   React.useEffect(() => {
+    // Register the state listener once on mount to avoid duplicate listeners
     listeners.push(setState)
     return () => {
       const index = listeners.indexOf(setState)
@@ -179,7 +180,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent duplicate listeners in toast hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 20 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a368f800ec8330916ad0589fd7b0fb