### PR TITLE
Fix DELISTING intent keyword spelling

### DIFF
--- a/backend/app/agents/intents.py
+++ b/backend/app/agents/intents.py
@@ -17,7 +17,7 @@ Intent = Literal[
 
 def classify_intent(q: str) -> Intent:
     s = q.lower()
-    if any(k in s for k in ["delist", "remove", "tail", "underperform", "rationaliz"]):
+    if any(k in s for k in ["delist", "remove", "tail", "underperform", "rationalize"]):
         return "DELISTING"
     if any(k in s for k in ["enlist", "launch", "add", "introduce", "new sku", "npi", "innovation"]):
         return "ENLISTING"


### PR DESCRIPTION
## Summary
- replace misspelled "rationaliz" with "rationalize" in intent classifier

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a37b32ed308330a83925a1e6006dd3