### PR TITLE
fix: remove conflicting flags from UI build

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -52,9 +52,7 @@ echo "🔨 Building frontend UI..."
 cd ui
 gcloud builds submit \
   --config cloudbuild.yaml \
-  --tag $REGION-docker.pkg.dev/$PROJECT_ID/$REPO/ppa-ui:latest \
-  --substitutions=_REGION=$REGION,_REPO=$REPO,_VITE_API_BASE=$API_URL \
-  --config cloudbuild.yaml
+  --substitutions=_REGION=$REGION,_REPO=$REPO,_VITE_API_BASE=$API_URL
 cd ..
 
 UI_IMG="$REGION-docker.pkg.dev/$PROJECT_ID/$REPO/ppa-ui:latest"


### PR DESCRIPTION
## Summary
- remove conflicting --tag from frontend build command and avoid repeating --config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a37d19c964833095893117d195b196