### PR TITLE
feat: add smoke tests for deployment

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -81,9 +81,10 @@ gcloud run services update ppa-api \
   --set-env-vars=CORS_ORIGINS=$UI_URL,OPENAI_MODEL=gpt-4o-mini \
   --set-env-vars=OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY not set}
 
-# Smoke test
-echo "🔎 Pinging health endpoint..."
-curl -sS $API_URL/healthz || true
+
+# Smoke tests
+echo "🧪 Running smoke tests..."
+"$(dirname "$0")/smoke_test.sh" "$API_URL" "$UI_URL"
 
 # Initialize data and train models
 echo "📊 Initializing demo data and training models..."

--- a/ops/smoke_test.sh
+++ b/ops/smoke_test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_URL=${1:-}
+UI_URL=${2:-}
+
+if [[ -z "$API_URL" || -z "$UI_URL" ]]; then
+  echo "Usage: $0 <api_url> <ui_url>" >&2
+  exit 1
+fi
+
+# Backend smoke test
+echo "🔎 Checking backend at $API_URL/healthz"
+BACKEND_RESP=$(curl -fsS "$API_URL/healthz")
+echo "  Response: $BACKEND_RESP"
+echo "$BACKEND_RESP" | grep -q '"ok"' || { echo "Backend health check failed" >&2; exit 1; }
+
+# Frontend smoke test
+echo "🔎 Checking frontend at $UI_URL"
+FRONTEND_RESP=$(curl -fsS "$UI_URL")
+if ! echo "$FRONTEND_RESP" | grep -qi '<title>'; then
+  echo "Frontend did not return expected HTML" >&2
+  exit 1
+fi
+
+echo "✅ Smoke tests passed"


### PR DESCRIPTION
## Summary
- add a reusable smoke test script that checks backend /healthz response and frontend HTML
- run the smoke tests automatically after deployment completes

## Testing
- `pytest backend/tests/test_intents.py`
- `bash ops/smoke_test.sh http://localhost:8000 http://localhost:8000`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a37f01953883309be08f207ae1d615