### PR TITLE
chore(ui): remove react-badge dependency

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,6 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slider": "^1.3.5",
     "@radix-ui/react-progress": "^1.1.7",
-    "@radix-ui/react-badge": "^1.1.0",
     "class-variance-authority": "^0.7.1",
     "tailwind-merge": "^2.6.0",
     "express": "^4.19.2",


### PR DESCRIPTION
## Summary
- remove unused @radix-ui/react-badge dependency from ui package

## Testing
- `npm test` (fails: Missing script: "test")
- `cd ui && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a380ad86bc8330b335fab69bbb9a74