### PR TITLE
Specify Dockerfile in Cloud Build configuration

### DIFF
--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build','-t','$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/ppa-ui:latest','.']
+  args: ['build','-t','$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/ppa-ui:latest','-f','ui/Dockerfile','.']
   env:
   - 'VITE_API_BASE=$_VITE_API_BASE'
 images:


### PR DESCRIPTION
## Summary
- reference `ui/Dockerfile` explicitly in Cloud Build args

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a380acd2fc83308649ce324ec54398