### PR TITLE
Simplify UI deploy step

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -53,21 +53,6 @@ gcloud builds submit . \
   --config ui/cloudbuild.yaml \
   --substitutions=_REGION=$REGION,_REPO=$REPO,_VITE_API_BASE=$API_URL
 
-UI_IMG="$REGION-docker.pkg.dev/$PROJECT_ID/$REPO/ppa-ui:latest"
-
-# Deploy UI to Cloud Run
-echo "🚀 Deploying UI to Cloud Run..."
-gcloud run deploy ppa-ui \
-  --image=$UI_IMG \
-  --region=$REGION \
-  --allow-unauthenticated \
-  --port=3000 \
-  --memory=1Gi \
-  --cpu=1 \
-  --timeout=60 \
-  --max-instances=5 \
-  --set-env-vars=VITE_API_BASE=$API_URL
-
 # Get UI URL
 UI_URL=$(gcloud run services describe ppa-ui --region=$REGION --format='value(status.url)')
 echo "  UI deployed at: $UI_URL"


### PR DESCRIPTION
## Summary
- streamline frontend build in deploy script by using Cloud Build with API URL substitution
- remove Cloud Run UI deployment block

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 20 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a382bf6760833087a6dd0a3af603ed