### PR TITLE
fix: start server with proper module format

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "node server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/server.js
+++ b/server.js
@@ -1,8 +1,11 @@
-const express = require("express");
-const path = require("path");
-const { createProxyMiddleware } = require("http-proxy-middleware");
+import express from "express";
+import path from "path";
+import { fileURLToPath } from "url";
+import { createProxyMiddleware } from "http-proxy-middleware";
 
 const app = express();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const DIST = path.join(__dirname, "dist");
 
 // API_URL must be the Cloud Run URL of the FastAPI service (no trailing slash)
@@ -23,7 +26,9 @@ app.use(
     timeout: 60000,
     onError(err, req, res) {
       console.error("Proxy error:", err?.message);
-      res.status(502).json({ error: "proxy_error", detail: err?.message || "unknown" });
+      res
+        .status(502)
+        .json({ error: "proxy_error", detail: err?.message || "unknown" });
     },
   })
 );
@@ -35,4 +40,9 @@ app.use(express.static(DIST));
 app.get("*", (_, res) => res.sendFile(path.join(DIST, "index.html")));
 
 const port = process.env.PORT || 3000;
-app.listen(port, () => console.log(`UI listening on ${port}; API proxy -> ${API_URL || "http://localhost:8080"}`));
+app.listen(port, () =>
+  console.log(
+    `UI listening on ${port}; API proxy -> ${API_URL || "http://localhost:8080"}`
+  )
+);
+

--- a/src/components/AssortmentSim.tsx
+++ b/src/components/AssortmentSim.tsx
@@ -11,7 +11,22 @@ interface AssortmentSimProps {
 
 const AssortmentSim: React.FC<AssortmentSimProps> = ({ className = "" }) => {
   const [selectedForDelist, setSelectedForDelist] = useState<number[]>([]);
-  const [simulationResult, setSimulationResult] = useState<any>(null);
+  interface SimulationRow {
+    id: number;
+    brand: string;
+    pack: string;
+    tier: string;
+    share?: number;
+    units: number;
+    new_units?: number;
+    volume_gain?: number;
+  }
+
+  interface DelistResult {
+    rows: SimulationRow[];
+  }
+
+  const [simulationResult, setSimulationResult] = useState<DelistResult | null>(null);
   const [loading, setLoading] = useState(false);
 
   // Mock SKU data
@@ -123,7 +138,7 @@ const AssortmentSim: React.FC<AssortmentSimProps> = ({ className = "" }) => {
           
           {simulationResult ? (
             <div className="space-y-3">
-              {simulationResult.rows.slice(0, 6).map((sku: any) => (
+              {simulationResult.rows.slice(0, 6).map((sku: SimulationRow) => (
                 <div key={sku.id} className="p-3 rounded-lg bg-card border border-border">
                   <div className="flex items-center justify-between">
                     <div className="space-y-1">
@@ -147,7 +162,7 @@ const AssortmentSim: React.FC<AssortmentSimProps> = ({ className = "" }) => {
               <div className="mt-4 p-3 rounded-lg bg-primary/10 border border-primary/20">
                 <p className="text-sm text-primary font-medium">
                   Total volume transferred: {simulationResult.rows
-                    .reduce((sum: number, sku: any) => sum + (sku.volume_gain || 0), 0)
+                    .reduce((sum: number, sku: SimulationRow) => sum + (sku.volume_gain || 0), 0)
                     .toLocaleString()} units
                 </p>
               </div>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,12 +18,17 @@ export interface KPIData {
 }
 
 export interface SimulationResult {
-  agg: Array<{week: number; units: number; revenue: number; margin: number}>;
-  rows: Array<any>;
+  agg: Array<{ week: number; units: number; revenue: number; margin: number }>;
+  rows: Array<Record<string, unknown>>;
+  summary?: {
+    volume_change: number;
+    revenue_change: number;
+    margin_change: number;
+  };
 }
 
 export interface OptimizationResult {
-  solution: Array<any>;
+  solution: Array<Record<string, unknown>>;
   kpis: {
     status: string;
     n_near_bound: number;
@@ -37,12 +42,12 @@ export interface HuddleResult {
     role: string;
     content: string;
     evidence?: string[];
-    kpis?: any;
-    recommendation?: any;
+    kpis?: Record<string, unknown>;
+    recommendation?: Record<string, unknown>;
     timestamp: string;
   }>;
   stopped_after_rounds: number;
-  final_recommendation?: any;
+  final_recommendation?: Record<string, unknown>;
 }
 
 // API calls (unchanged except they now always go through /api)
@@ -50,9 +55,12 @@ export const apiService = {
   generateData: () => api.post("/data/generate"),
   trainModels: () => api.post("/models/train"),
 
-  simulatePrice: (changes: Record<string, number>): Promise<{data: SimulationResult}> =>
-    api.post("/simulate/price", changes),
-  simulateDelist: (ids: number[]): Promise<{data: {rows: any[]}}> =>
+  simulatePrice: (
+    changes: Record<string, number>
+  ): Promise<{ data: SimulationResult }> => api.post("/simulate/price", changes),
+  simulateDelist: (
+    ids: number[]
+  ): Promise<{ data: { rows: Array<Record<string, unknown>> } }> =>
     api.post("/simulate/delist", ids),
 
   runOptimizer: (round: number = 1): Promise<{data: OptimizationResult}> =>

--- a/src/pages/RAGSearch.tsx
+++ b/src/pages/RAGSearch.tsx
@@ -29,7 +29,7 @@ export default function RAGSearch() {
         timeout: 30000
       });
       setHits(response.data.hits || []);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error("RAG search failed:", e);
       setError("Search failed. Please check your connection and try again.");
       setHits([]);

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -7,13 +7,13 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import ChartWithInsight from '../components/ChartWithInsight';
 import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { Play, RotateCcw, TrendingUp, TrendingDown, DollarSign, Package } from 'lucide-react';
-import { apiService } from '../lib/api';
+import { apiService, SimulationResult } from '../lib/api';
 
 const Simulator: React.FC = () => {
   const [priceChanges, setPriceChanges] = useState<Record<string, number>>({});
   const [selectedRegion, setSelectedRegion] = useState<string>('All');
   const [selectedChannel, setSelectedChannel] = useState<string>('All');
-  const [simulationResult, setSimulationResult] = useState<any>(null);
+  const [simulationResult, setSimulationResult] = useState<SimulationResult | null>(null);
   const [loading, setLoading] = useState(false);
 
   // Mock SKU data for controls

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -102,5 +103,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- convert Node UI server to ES modules
- add start script for Cloud Run
- replace `any` types with structured interfaces across UI and API utilities
- switch Tailwind plugin to ESM import for lint compliance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`
- `PORT=8080 node server.js`


------
https://chatgpt.com/codex/tasks/task_e_68a38db5812883308c71d5462d3e3bd9