### PR TITLE
fix: install runtime deps and improve uvicorn startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,21 @@
 FROM python:3.11-slim
+
+# Install system dependencies required by scientific Python libraries
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libgomp1 \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
-COPY app /app/app
+
+# Install Python dependencies first to leverage Docker layer caching
 COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r /app/requirements.txt
+
+# Copy application code
+COPY app /app/app
+
 EXPOSE 8080
-CMD ["bash","-lc","uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]
+
+# Use sh for PORT substitution and ensure uvicorn becomes PID 1 via exec
+CMD ["sh","-c","exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]


### PR DESCRIPTION
## Summary
- install build-essential and libgomp1 so scikit-learn and other scientific libs load correctly
- move dependency install ahead of source copy and exec uvicorn directly for proper signal handling

## Testing
- `pytest backend/tests/test_intents.py`


------
https://chatgpt.com/codex/tasks/task_e_68a393dd16908330ac42fc39cfb8f44c