### PR TITLE
fix: adjust OpenAI client for httpx 0.28+

### DIFF
--- a/backend/app/rag/store.py
+++ b/backend/app/rag/store.py
@@ -6,6 +6,8 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from ..utils.io import engine
 
+import httpx
+
 try:
     import faiss  # optional
     FAISS_OK = True
@@ -20,7 +22,8 @@ def _get_openai():
     if _OPENAI is None:
         try:
             from openai import OpenAI
-            _OPENAI = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+            http_client = httpx.Client(follow_redirects=True, timeout=60, trust_env=False)
+            _OPENAI = OpenAI(api_key=os.getenv("OPENAI_API_KEY"), http_client=http_client)
         except Exception:
             _OPENAI = None
     return _OPENAI

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ python-multipart==0.0.9
 pydantic==2.8.2
 jinja2==3.1.4
 openai==1.43.0
+httpx==0.27.2
 pyarrow==17.0.0
 sqlalchemy==2.0.32
 google-generativeai==0.8.3


### PR DESCRIPTION
## Summary
- avoid deprecated `proxies` argument by providing a custom `httpx.Client` when creating OpenAI instances
- pin `httpx` to a compatible release for backend

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f8ac0ab8833080e8c5020999ea18