### PR TITLE
fix: bind server and align Dockerfile start

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ app.use(express.static(DIST));
 app.get("*", (_, res) => res.sendFile(path.join(DIST, "index.html")));
 
 const port = process.env.PORT || 3000;
-app.listen(port, () =>
+app.listen(port, '0.0.0.0', () =>
   console.log(
     `UI listening on ${port}; API proxy -> ${API_URL || "http://localhost:8080"}`
   )

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:20-slim
+ENV PORT=3000
 WORKDIR /ui
 COPY package.json package-lock.json* ./
 RUN npm ci || npm install
 COPY . .
 RUN npm run build
 EXPOSE 3000
-CMD ["npm", "run", "serve"]
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- ensure express server listens on 0.0.0.0 for Cloud Run
- set default PORT and use `npm start` in UI Dockerfile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a41455fd3c8330ad7d6da1e4fbb8ba