### PR TITLE
fix: use stable Cloud Run URLs

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -44,7 +44,7 @@ gcloud run deploy ppa-api \
   --max-instances=10
 
 # Get API URL
-API_URL=$(gcloud run services describe ppa-api --region=$REGION --format='value(status.url)')
+API_URL=$(gcloud run services describe ppa-api --region=$REGION --format='value(status.address.url)')
 echo "  API deployed at: $API_URL"
 
 # Build UI with API URL
@@ -69,7 +69,7 @@ gcloud run deploy ppa-ui \
   --set-env-vars=API_URL=$API_URL,VITE_API_BASE=$API_URL
   
 # Get UI URL
-UI_URL=$(gcloud run services describe ppa-ui --region=$REGION --format='value(status.url)')
+UI_URL=$(gcloud run services describe ppa-ui --region=$REGION --format='value(status.address.url)')
 echo "  UI deployed at: $UI_URL"
 
 # Configure CORS and OpenAI env on API


### PR DESCRIPTION
## Summary
- use `status.address.url` to fetch API/UI URLs in deploy script so Cloud Run services use stable project-number domains

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4166d1a7c8330b10e7fffcf00a3b7