### PR TITLE
fix: use stable Cloud Run URLs in deployment script

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -43,8 +43,8 @@ gcloud run deploy ppa-api \
   --timeout=300 \
   --max-instances=10
 
-# Get API URL
-API_URL=$(gcloud run services describe ppa-api --region=$REGION --format='value(status.address.url)')
+# Get API URL (use Cloud Run-provided URL to avoid custom-domain latency issues)
+API_URL=$(gcloud run services describe ppa-api --region=$REGION --format='value(status.url)')
 echo "  API deployed at: $API_URL"
 
 # Build UI with API URL
@@ -68,8 +68,8 @@ gcloud run deploy ppa-ui \
   --max-instances=5 \
   --set-env-vars=API_URL=$API_URL,VITE_API_BASE=$API_URL
   
-# Get UI URL
-UI_URL=$(gcloud run services describe ppa-ui --region=$REGION --format='value(status.address.url)')
+# Get UI URL (always the default Cloud Run URL)
+UI_URL=$(gcloud run services describe ppa-ui --region=$REGION --format='value(status.url)')
 echo "  UI deployed at: $UI_URL"
 
 # Configure CORS and OpenAI env on API


### PR DESCRIPTION
## Summary
- ensure `deploy.sh` fetches default Cloud Run URLs for API and UI
- avoid custom domain mapping to fix 404 health check and UI 500 errors

## Testing
- `pytest backend/tests/test_intents.py`

------
https://chatgpt.com/codex/tasks/task_e_68a423a10b8c8330bb728a6f24fb9ca3