### PR TITLE
Ensure /healthz endpoint responds correctly

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,8 +27,9 @@ app.add_middleware(
 def root():
     return {"message": "iNRM PPA+Assortment API", "version": "1.0.0"}
 
-@app.get("/healthz")
+@app.api_route("/healthz", methods=["GET", "HEAD"], include_in_schema=False)
 def healthz():
+    """Health check endpoint used by Cloud Run and monitoring probes."""
     return {"ok": True}
 
 @app.get("/health")

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+# Ensure the app package is importable
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from app.main import app
+
+client = TestClient(app)
+
+def test_healthz_get():
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+def test_healthz_head():
+    resp = client.head("/healthz")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Handle GET and HEAD requests for `/healthz` to fix health check 404s
- Add tests validating `/healthz` responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a44b20e4c483308f49556c413745ce