### PR TITLE
Handle health check fallback and configurable API base

### DIFF
--- a/ops/smoke_test.sh
+++ b/ops/smoke_test.sh
@@ -11,9 +11,15 @@ fi
 
 # Backend smoke test
 echo "🔎 Checking backend at $API_URL/healthz"
-BACKEND_RESP=$(curl -fsS "$API_URL/healthz")
+# Try /healthz first; fall back to /health if needed
+if ! BACKEND_RESP=$(curl -fsS "$API_URL/healthz" 2>/dev/null); then
+  echo "  /healthz not found, trying /health"
+  BACKEND_RESP=$(curl -fsS "$API_URL/health" 2>/dev/null) || {
+    echo "Backend health check failed" >&2; exit 1; }
+fi
 echo "  Response: $BACKEND_RESP"
-echo "$BACKEND_RESP" | grep -q '"ok"' || { echo "Backend health check failed" >&2; exit 1; }
+# Accept either {"ok": true} or {"status": "healthy"}
+echo "$BACKEND_RESP" | grep -Eq '"ok"|"status"' || { echo "Backend health check failed" >&2; exit 1; }
 
 # Frontend smoke test
 echo "🔎 Checking frontend at $UI_URL"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,9 @@
 import axios from "axios";
 
-// Always use same-origin proxy; Express will forward /api/* -> FastAPI
-export const API_BASE = "/api";
+// Determine API base: allow localStorage override, build-time env or fallback to proxy
+const storedOverride =
+  typeof window !== "undefined" ? localStorage.getItem("API_BASE_OVERRIDE") : null;
+export const API_BASE = storedOverride || import.meta.env.VITE_API_BASE || "/api";
 
 const api = axios.create({
   baseURL: API_BASE,


### PR DESCRIPTION
## Summary
- fall back to `/health` if `/healthz` 404s during smoke test
- allow UI to read `VITE_API_BASE` or local override for API calls

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a45e3fc4c48330a46eaec9e66e77e6