### PR TITLE
feat: load API keys from secret manager

### DIFF
--- a/backend/app/agents/llm.py
+++ b/backend/app/agents/llm.py
@@ -3,10 +3,11 @@ from typing import List, Dict, Any
 
 import httpx
 
-from ..utils.secrets import get_gemini_api_key
+from ..utils.secrets import get_gemini_api_key, get_openai_api_key
 
+_OPENAI_API_KEY = get_openai_api_key()
 # Try OpenAI first
-OPENAI_OK = bool(os.getenv("OPENAI_API_KEY"))
+OPENAI_OK = bool(_OPENAI_API_KEY)
 _GEMINI_API_KEY = get_gemini_api_key()
 GEMINI_OK = bool(_GEMINI_API_KEY)
 
@@ -17,7 +18,7 @@ if OPENAI_OK:
     # when auto-detecting proxy settings. Construct a client ourselves so
     # the SDK doesn't try to pass the deprecated argument.
     _http_client = httpx.Client(follow_redirects=True, timeout=60, trust_env=False)
-    _oai = OpenAI(api_key=os.getenv("OPENAI_API_KEY"), http_client=_http_client)
+    _oai = OpenAI(api_key=_OPENAI_API_KEY, http_client=_http_client)
 
 def _openai_chat_json(messages, temperature, top_p, model):
     resp = _oai.chat.completions.create(

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,8 +1,9 @@
 import os
 from pathlib import Path
+from .utils.secrets import get_openai_api_key
 
 # Environment variables and dependencies
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+OPENAI_API_KEY = get_openai_api_key() or ""
 PROJECT_ID = os.getenv("PROJECT_ID", "")
 REGION = os.getenv("REGION", "asia-south1")
 
@@ -10,3 +11,4 @@ REGION = os.getenv("REGION", "asia-south1")
 BASE_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = BASE_DIR / "data"
 DATA_DIR.mkdir(parents=True, exist_ok=True)
+

--- a/backend/app/rag/store.py
+++ b/backend/app/rag/store.py
@@ -5,6 +5,7 @@ import pandas as pd
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from ..utils.io import engine
+from ..utils.secrets import get_openai_api_key
 
 import httpx
 
@@ -23,7 +24,7 @@ def _get_openai():
         try:
             from openai import OpenAI
             http_client = httpx.Client(follow_redirects=True, timeout=60, trust_env=False)
-            _OPENAI = OpenAI(api_key=os.getenv("OPENAI_API_KEY"), http_client=http_client)
+            _OPENAI = OpenAI(api_key=get_openai_api_key(), http_client=http_client)
         except Exception:
             _OPENAI = None
     return _OPENAI
@@ -87,7 +88,7 @@ class RAGStore:
         self.docs, self.meta = blobs, meta
 
         # Try FAISS with OpenAI embeddings; fallback to TF-IDF
-        use_dense = bool(os.getenv("OPENAI_API_KEY")) and FAISS_OK
+        use_dense = bool(get_openai_api_key()) and FAISS_OK
         if use_dense:
             try:
                 vecs = _embed_texts(self.docs)

--- a/backend/app/utils/secrets.py
+++ b/backend/app/utils/secrets.py
@@ -1,10 +1,9 @@
 import os
 from functools import lru_cache
 
-@lru_cache()
-def get_gemini_api_key() -> str | None:
-    """Retrieve Gemini API key from env or Google Secret Manager."""
-    key = os.getenv("GEMINI_API_KEY")
+def _fetch_secret(env_key: str, default_secret: str, secret_env: str) -> str | None:
+    """Generic helper to fetch secrets from env or Google Secret Manager."""
+    key = os.getenv(env_key)
     if key:
         return key
     try:
@@ -12,10 +11,22 @@ def get_gemini_api_key() -> str | None:
         project_id = os.getenv("PROJECT_ID") or os.getenv("GCP_PROJECT") or os.getenv("GOOGLE_CLOUD_PROJECT")
         if not project_id:
             return None
-        secret_name = os.getenv("GEMINI_API_KEY_SECRET", "gemini-api-key")
+        secret_name = os.getenv(secret_env, default_secret)
         client = secretmanager.SecretManagerServiceClient()
         name = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
         response = client.access_secret_version(request={"name": name})
         return response.payload.data.decode("UTF-8")
     except Exception:
         return None
+
+
+@lru_cache()
+def get_gemini_api_key() -> str | None:
+    """Retrieve Gemini API key from env or Google Secret Manager."""
+    return _fetch_secret("GEMINI_API_KEY", "gemini-api-key", "GEMINI_API_KEY_SECRET")
+
+
+@lru_cache()
+def get_openai_api_key() -> str | None:
+    """Retrieve OpenAI API key from env or Google Secret Manager."""
+    return _fetch_secret("OPENAI_API_KEY", "open-ai-api-key", "OPENAI_API_KEY_SECRET")

--- a/ops/README.md
+++ b/ops/README.md
@@ -161,6 +161,7 @@ The following are automatically configured by Cloud Run:
 - `PROJECT_ID`: GCP project identifier
 - `REGION`: Deployment region
 - `GEMINI_API_KEY`: Retrieved from Secret Manager (`gemini-api-key`)
+- `OPENAI_API_KEY`: Retrieved from Secret Manager (`open-ai-api-key`)
 
 ## 📊 Data Model
 

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -8,6 +8,7 @@ PROJECT_ID=${PROJECT_ID:-$(gcloud config get-value project)}
 REGION=${REGION:-asia-south1}
 REPO=${REPO:-ppa-assortment-repo}
 GEMINI_SECRET=${GEMINI_SECRET:-gemini-api-key}
+OPENAI_SECRET=${OPENAI_SECRET:-open-ai-api-key}
 
 echo "📋 Configuration:"
 echo "  Project ID: $PROJECT_ID"
@@ -78,8 +79,7 @@ echo "🔧 Configuring API environment..."
 gcloud run services update ppa-api \
   --region=$REGION \
   --set-env-vars=CORS_ORIGINS=$UI_URL,OPENAI_MODEL=gpt-4o-mini \
-  --set-env-vars=OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY not set} \
-  --set-secrets=GEMINI_API_KEY=$GEMINI_SECRET:latest
+  --set-secrets=OPENAI_API_KEY=$OPENAI_SECRET:latest,GEMINI_API_KEY=$GEMINI_SECRET:latest
 
 
 # Smoke tests


### PR DESCRIPTION
## Summary
- fetch OpenAI and Gemini API keys from GCP Secret Manager
- update deployment script to mount OpenAI secret and drop env dependency
- document OPENAI_API_KEY secret usage

## Testing
- `python -m py_compile backend/app/utils/secrets.py backend/app/rag/store.py backend/app/agents/llm.py backend/app/deps.py`
- `bash -n ops/deploy.sh`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d70533d48330a90a61316abd6945