### PR TITLE
feat: send chart data to Gemini and boost deployment memory

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -40,9 +40,9 @@ gcloud run deploy ppa-api \
   --region=$REGION \
   --allow-unauthenticated \
   --port=8080 \
-  --memory=2Gi \
-  --cpu=1 \
-  --timeout=300 \
+  --memory=4Gi \
+  --cpu=2 \
+  --timeout=600 \
   --max-instances=10
 
 # Get API URL (use Cloud Run-provided URL to avoid custom-domain latency issues)
@@ -64,9 +64,9 @@ gcloud run deploy ppa-ui \
   --region=$REGION \
   --allow-unauthenticated \
   --port=3000 \
-  --memory=1Gi \
+  --memory=2Gi \
   --cpu=1 \
-  --timeout=60 \
+  --timeout=120 \
   --max-instances=5 \
   --set-env-vars=API_URL=$API_URL,VITE_API_BASE=$API_URL
   

--- a/src/components/ChartWithInsight.tsx
+++ b/src/components/ChartWithInsight.tsx
@@ -9,13 +9,15 @@ interface ChartWithInsightProps {
   title: string;
   children: React.ReactNode;
   className?: string;
+  data?: Array<Record<string, unknown>>;
 }
 
-const ChartWithInsight: React.FC<ChartWithInsightProps> = ({ 
-  panelId, 
-  title, 
-  children, 
-  className = "" 
+const ChartWithInsight: React.FC<ChartWithInsightProps> = ({
+  panelId,
+  title,
+  children,
+  className = "",
+  data = []
 }) => {
   const [insight, setInsight] = useState<string>("");
   const [loading, setLoading] = useState(false);
@@ -24,8 +26,8 @@ const ChartWithInsight: React.FC<ChartWithInsightProps> = ({
   const generateInsight = async () => {
     setLoading(true);
     try {
-      const { data } = await apiService.getInsight(panelId, title);
-      setInsight(data.insight);
+      const { data: resp } = await apiService.getInsight(panelId, title, data);
+      setInsight(resp.insight);
       setShowInsight(true);
     } catch (error) {
       console.error('Insight generation failed, using fallback:', error);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -71,8 +71,12 @@ export const apiService = {
   ragSearch: (q: string): Promise<{data: {hits: Array<{doc: string; score: number}>}}> =>
     api.get("/rag/search", { params: { q } }),
 
-  getInsight: (panelId: string, q?: string): Promise<{data: {insight: string}}> =>
-    api.get("/genai/insight", { params: { panel_id: panelId, q } }),
+  getInsight: (
+    panelId: string,
+    q?: string,
+    data?: Array<Record<string, unknown>>
+  ): Promise<{data: {insight: string}}> =>
+    api.post("/genai/insight", { panel_id: panelId, q, data }),
 
   agenticHuddle: (question: string, budget?: number) =>
     api.post("/huddle/run", { q: question, budget }),

--- a/src/pages/Assortment.tsx
+++ b/src/pages/Assortment.tsx
@@ -68,7 +68,7 @@ const Assortment: React.FC = () => {
       </div>
 
       {/* MSL vs Actual Performance */}
-      <ChartWithInsight panelId="msl-compliance" title="MSL vs Actual Distribution">
+      <ChartWithInsight panelId="msl-compliance" title="MSL vs Actual Distribution" data={mslData}>
         <div className="h-80">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={mslData} margin={{ top: 20, right: 30, bottom: 100, left: 60 }}>

--- a/src/pages/Elasticities.tsx
+++ b/src/pages/Elasticities.tsx
@@ -78,7 +78,7 @@ const Elasticities: React.FC = () => {
 
       {/* Attribute Importance & Promo Analysis */}
       <div className="grid lg:grid-cols-2 gap-6">
-        <ChartWithInsight panelId="attribute-importance" title="Attribute Importance (Random Forest SHAP)">
+        <ChartWithInsight panelId="attribute-importance" title="Attribute Importance (Random Forest SHAP)" data={attributeData}>
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
               <ScatterChart margin={{ top: 20, right: 80, bottom: 60, left: 140 }}>
@@ -136,7 +136,7 @@ const Elasticities: React.FC = () => {
           </div>
         </ChartWithInsight>
 
-        <ChartWithInsight panelId="promo-uplift" title="Promotional Uplift Curves">
+        <ChartWithInsight panelId="promo-uplift" title="Promotional Uplift Curves" data={promoData}>
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={promoData} margin={{ top: 20, right: 30, bottom: 60, left: 60 }}>
@@ -181,7 +181,7 @@ const Elasticities: React.FC = () => {
       </div>
 
       {/* Seasonality & Calendar Effects */}
-      <ChartWithInsight panelId="seasonality" title="Seasonality & Calendar Effects">
+      <ChartWithInsight panelId="seasonality" title="Seasonality & Calendar Effects" data={seasonalityData}>
         <div className="h-80">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={seasonalityData} margin={{ top: 20, right: 30, bottom: 60, left: 60 }}>

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -90,7 +90,7 @@ const Landing: React.FC = () => {
 
       {/* Trend Charts */}
       <div className="grid lg:grid-cols-2 gap-6">
-        <ChartWithInsight panelId="revenue-trend" title="Revenue & Volume Trends">
+        <ChartWithInsight panelId="revenue-trend" title="Revenue & Volume Trends" data={trendData}>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={trendData}>
@@ -123,7 +123,7 @@ const Landing: React.FC = () => {
           </div>
         </ChartWithInsight>
 
-        <ChartWithInsight panelId="channel-mix" title="Channel Performance Mix">
+        <ChartWithInsight panelId="channel-mix" title="Channel Performance Mix" data={channelData}>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
@@ -168,7 +168,7 @@ const Landing: React.FC = () => {
       </div>
 
       {/* Brand Performance */}
-      <ChartWithInsight panelId="brand-performance" title="Brand Performance: Revenue vs Margin %">
+      <ChartWithInsight panelId="brand-performance" title="Brand Performance: Revenue vs Margin %" data={brandPerformance}>
         <div className="h-80">
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart data={brandPerformance} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>

--- a/src/pages/PPA.tsx
+++ b/src/pages/PPA.tsx
@@ -48,7 +48,7 @@ const PPA: React.FC = () => {
       </div>
 
       {/* Price Ladder Analysis */}
-      <ChartWithInsight panelId="price-ladder" title="Pack Ladder & Price Per ml">
+      <ChartWithInsight panelId="price-ladder" title="Pack Ladder & Price Per ml" data={priceLadder}>
         <div className="h-80">
           <ResponsiveContainer width="100%" height="100%">
             <ScatterChart margin={{ top: 20, right: 30, bottom: 60, left: 80 }}>
@@ -127,7 +127,7 @@ const PPA: React.FC = () => {
 
       {/* Price Per ML Analysis */}
       <div className="grid lg:grid-cols-2 gap-6">
-        <ChartWithInsight panelId="ppm-analysis" title="Price Per ml Efficiency">
+        <ChartWithInsight panelId="ppm-analysis" title="Price Per ml Efficiency" data={ppmData}>
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={ppmData} margin={{ top: 20, right: 30, bottom: 80, left: 80 }}>
@@ -200,7 +200,7 @@ const PPA: React.FC = () => {
       </div>
 
       {/* Whitespace Opportunities */}
-      <ChartWithInsight panelId="whitespace-matrix" title="Whitespace Opportunity Matrix">
+      <ChartWithInsight panelId="whitespace-matrix" title="Whitespace Opportunity Matrix" data={whitespaceData}>
         <div className="grid lg:grid-cols-2 gap-6">
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -288,7 +288,7 @@ const Simulator: React.FC = () => {
 
           {/* Trend Charts */}
           <div className="grid lg:grid-cols-2 gap-6">
-            <ChartWithInsight panelId="volume-trend" title="Volume Response Over Time">
+            <ChartWithInsight panelId="volume-trend" title="Volume Response Over Time" data={simulationResult.agg}>
               <div className="h-80">
                 <ResponsiveContainer width="100%" height="100%">
                   <LineChart data={simulationResult.agg} margin={{ top: 20, right: 30, bottom: 60, left: 60 }}>
@@ -331,7 +331,7 @@ const Simulator: React.FC = () => {
               </div>
             </ChartWithInsight>
 
-            <ChartWithInsight panelId="margin-trend" title="Margin Evolution">
+            <ChartWithInsight panelId="margin-trend" title="Margin Evolution" data={simulationResult.agg}>
               <div className="h-80">
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={simulationResult.agg} margin={{ top: 20, right: 30, bottom: 60, left: 60 }}>


### PR DESCRIPTION
## Summary
- accept chart data in `/genai/insight` and feed Gemini real tables
- pass chart datasets from UI components and API service
- raise Cloud Run memory/timeout in deploy script

## Testing
- `pytest`
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4dcaf637883309f6ab27f32fb085f