### PR TITLE
feat: allow api token for secured huddle

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,10 +5,20 @@ const storedOverride =
   typeof window !== "undefined" ? localStorage.getItem("API_BASE_OVERRIDE") : null;
 export const API_BASE = storedOverride || import.meta.env.VITE_API_BASE || "/api";
 
+// Optional auth token for secured APIs
+const storedToken =
+  typeof window !== "undefined" ? localStorage.getItem("API_TOKEN") : null;
+export const API_TOKEN = storedToken || import.meta.env.VITE_API_TOKEN || "";
+
 const api = axios.create({
   baseURL: API_BASE,
   timeout: 60000,
 });
+
+if (API_TOKEN) {
+  api.defaults.headers.common["Authorization"] = `Bearer ${API_TOKEN}`;
+  axios.defaults.headers.common["Authorization"] = `Bearer ${API_TOKEN}`;
+}
 
 // Types (unchanged)
 export interface KPIData {


### PR DESCRIPTION
## Summary
- support optional bearer token for API requests
- allow configuring API base and token in Agentic Huddle settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5824d64c883309274226a4d4fd913