### PR TITLE
Standardize agent timeouts to 10 minutes

### DIFF
--- a/backend/app/agents/llm.py
+++ b/backend/app/agents/llm.py
@@ -20,7 +20,7 @@ def _get_openai_client():
         # httpx>=0.28 removed the ``proxies`` kwarg used by the OpenAI client
         # when auto-detecting proxy settings. Construct a client ourselves so
         # the SDK doesn't try to pass the deprecated argument.
-        _http_client = httpx.Client(follow_redirects=True, timeout=60, trust_env=False)
+        _http_client = httpx.Client(follow_redirects=True, timeout=600, trust_env=False)
         _oai_client = OpenAI(api_key=key, http_client=_http_client)
     return _oai_client
 
@@ -32,7 +32,7 @@ def _openai_chat_json(messages, temperature, top_p, model):
         model=model or os.getenv("OPENAI_MODEL","gpt-4o"),
         temperature=temperature, top_p=top_p,
         response_format={"type": "json_object"},
-        messages=messages, timeout=45
+        messages=messages, timeout=600
     )
     content = resp.choices[0].message.content or "{}"
     return json.loads(content)
@@ -48,7 +48,7 @@ def _gemini_chat_json(messages, temperature, top_p):
     usr = "\n".join(m["content"] for m in messages if m["role"]=="user")
     prompt = f"{sys}\n\n{usr}\n\nReturn ONLY valid JSON."
     model_name = os.getenv("GEMINI_MODEL","gemini-1.5-flash")
-    r = genai.GenerativeModel(model_name).generate_content(prompt, request_options={"timeout":45})
+    r = genai.GenerativeModel(model_name).generate_content(prompt, request_options={"timeout":600})
     text = (r.text or "{}").strip()
     # try to locate JSON substring if extra tokens appear
     start = text.find("{")

--- a/backend/app/rag/store.py
+++ b/backend/app/rag/store.py
@@ -24,7 +24,7 @@ def _get_openai():
     if _OPENAI is None:
         try:
             from openai import OpenAI
-            http_client = httpx.Client(follow_redirects=True, timeout=60, trust_env=False)
+            http_client = httpx.Client(follow_redirects=True, timeout=600, trust_env=False)
             _OPENAI = OpenAI(api_key=get_openai_api_key(), http_client=http_client)
         except Exception:
             _OPENAI = None

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const app = express();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DIST = path.join(__dirname, "dist");
-const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS) || 120000;
+const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS) || 600000;
 
 // API_URL must be the Cloud Run URL of the FastAPI service (no trailing slash)
 const API_URL = process.env.API_URL;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,7 +11,7 @@ const storedToken =
 export const API_TOKEN = storedToken || import.meta.env.VITE_API_TOKEN || "";
 
 export const REQUEST_TIMEOUT_MS =
-  Number(import.meta.env.VITE_REQUEST_TIMEOUT_MS) || 120000;
+  Number(import.meta.env.VITE_REQUEST_TIMEOUT_MS) || 600000;
 
 const api = axios.create({
   baseURL: API_BASE,

--- a/src/pages/RAGSearch.tsx
+++ b/src/pages/RAGSearch.tsx
@@ -26,7 +26,7 @@ export default function RAGSearch() {
     try {
       const response = await axios.get(`${API_BASE}/rag/search`, { 
         params: { q, topk: 6 },
-        timeout: 30000
+        timeout: 600000
       });
       setHits(response.data.hits || []);
     } catch (e: unknown) {

--- a/ui/server.js
+++ b/ui/server.js
@@ -4,7 +4,7 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 
 const app = express();
 const DIST = path.join(__dirname, "dist");
-const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS) || 120000;
+const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS) || 600000;
 
 // API_URL must be the Cloud Run URL of the FastAPI service (no trailing slash)
 const API_URL = process.env.API_URL;

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -8,7 +8,7 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 const DIST = path.join(__dirname, "dist");
-const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS) || 120000;
+const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS) || 600000;
 
 // Cloud Run URL of FastAPI (no trailing slash), e.g. https://ppa-api-xxxxx.a.run.app
 const API_URL = process.env.API_URL;


### PR DESCRIPTION
## Summary
- Extend proxy and client request timeout defaults to 10 minutes
- Allow RAG search and backend LLM/rag components up to 10-minute operations

## Testing
- `npm test` (fails: Missing script "test")
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5c583bbc88330a48a3a6a6a6e8821