### PR TITLE
Limit agent collaboration to three rounds

### DIFF
--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -55,8 +55,9 @@ def _make_fallback_plan(question: str, budget: float) -> Dict[str, Any]:
 def agentic_huddle_v2(
     question: str,
     budget: float = 5e5,
-    debate_rounds: int = 2,
+    debate_rounds: int = 3,
 ) -> Dict[str, Any]:
+    debate_rounds = min(debate_rounds, 3)
     hits = rag.query(question, topk=4)
     context = [h["text"] for h in hits]
     transcript: List[Dict[str, Any]] = []

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -133,13 +133,14 @@ def huddle(question: str, budget: float = 500000):
 def huddle_run(
     q: Optional[str] = Query(None),
     budget: float = Query(500000),
-    rounds: int = Query(2),
+    rounds: int = Query(3),
     body: dict | None = None,
 ):
     if body:
         q = body.get("q", q)
         budget = float(body.get("budget", budget))
-        rounds = int(body.get("rounds", rounds))
+        rounds = min(int(body.get("rounds", rounds)), 3)
+    rounds = min(rounds, 3)
     if not q:
         raise HTTPException(status_code=400, detail="Missing 'q' (question)")
     return agentic_huddle_v2(q, budget=budget, debate_rounds=rounds)

--- a/src/components/AgenticHuddle.tsx
+++ b/src/components/AgenticHuddle.tsx
@@ -65,7 +65,11 @@ export default function AgenticHuddle() {
     "Agents are collaborating...",
   ]);
 
-  const DEBATE_ROUNDS = Number(import.meta.env.VITE_DEBATE_ROUNDS) || 2;
+  // Cap debate rounds at 3 to avoid infinite collaboration
+  const DEBATE_ROUNDS = Math.min(
+    Number(import.meta.env.VITE_DEBATE_ROUNDS) || 3,
+    3
+  );
 
   const getProgressMessages = (question: string): string[] => {
     const lower = question.toLowerCase();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -91,7 +91,7 @@ export const apiService = {
   ): Promise<{data: {insight: string}}> =>
     api.post("/genai/insight", { panel_id: panelId, q, data }),
 
-  agenticHuddle: (question: string, budget?: number, rounds: number = 2) =>
+  agenticHuddle: (question: string, budget?: number, rounds: number = 3) =>
     api.post("/huddle/run", { q: question, budget, rounds }),
 
   health: () => api.get("/healthz"),


### PR DESCRIPTION
## Summary
- Cap debate rounds at three to avoid endless agent collaboration
- Propagate three-round limit through frontend API calls and server handlers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5f0d173e08330b1a10cb6b5a3442c