### PR TITLE
Parallelize agent deliberation to improve response time

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -88,10 +88,15 @@ echo "🧪 Running smoke tests..."
 # Initialize data and train models
 echo "📊 Initializing demo data and training models..."
 echo "  Generating synthetic data..."
-curl -f -X POST $API_URL/data/generate || echo "  ⚠️  Data generation may have failed"
+curl -f --max-time 60 -X POST $API_URL/data/generate &
+GEN_PID=$!
 
 echo "  Training elasticity models..."
-curl -f -X POST $API_URL/models/train || echo "  ⚠️  Model training may have failed"
+curl -f --max-time 120 -X POST $API_URL/models/train &
+TRAIN_PID=$!
+
+wait $GEN_PID || echo "  ⚠️  Data generation may have failed"
+wait $TRAIN_PID || echo "  ⚠️  Model training may have failed"
 
 # Final success message
 echo ""

--- a/ops/smoke_test.sh
+++ b/ops/smoke_test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 API_URL=${1:-}
 UI_URL=${2:-}
+CURL_OPTS=(--fail --silent --show-error --max-time 10)
 
 if [[ -z "$API_URL" || -z "$UI_URL" ]]; then
   echo "Usage: $0 <api_url> <ui_url>" >&2
@@ -12,9 +13,9 @@ fi
 # Backend smoke test
 echo "🔎 Checking backend at $API_URL/healthz"
 # Try /healthz first; fall back to /health if needed
-if ! BACKEND_RESP=$(curl -fsS "$API_URL/healthz" 2>/dev/null); then
+if ! BACKEND_RESP=$(curl "${CURL_OPTS[@]}" "$API_URL/healthz" 2>/dev/null); then
   echo "  /healthz not found, trying /health"
-  BACKEND_RESP=$(curl -fsS "$API_URL/health" 2>/dev/null) || {
+  BACKEND_RESP=$(curl "${CURL_OPTS[@]}" "$API_URL/health" 2>/dev/null) || {
     echo "Backend health check failed" >&2; exit 1; }
 fi
 echo "  Response: $BACKEND_RESP"
@@ -23,7 +24,7 @@ echo "$BACKEND_RESP" | grep -Eq '"ok"|"status"' || { echo "Backend health check 
 
 # Frontend smoke test
 echo "🔎 Checking frontend at $UI_URL"
-FRONTEND_RESP=$(curl -fsS "$UI_URL")
+FRONTEND_RESP=$(curl "${CURL_OPTS[@]}" "$UI_URL")
 if ! echo "$FRONTEND_RESP" | grep -qi '<title>'; then
   echo "Frontend did not return expected HTML" >&2
   exit 1


### PR DESCRIPTION
## Summary
- run agent LLM calls in parallel during round 1 and round 2
- import ThreadPoolExecutor for concurrency
- fail fast when Gemini API key is missing and ensure optimizer fallback returns quickly
- add curl timeouts and parallel data/model setup to speed smoke tests and deployment

## Testing
- `pytest backend/tests/test_health.py backend/tests/test_intents.py -q`
- `pytest backend/tests/test_huddle_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc11eabb88330bcb608819b314b9a