### PR TITLE
Handle long-running data generation and training asynchronously

### DIFF
--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+# Ensure the app package is importable
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_generate_returns_immediately(monkeypatch):
+    # Avoid running the heavy generation logic during tests
+    monkeypatch.setattr("app.main.gen_weekly_data", lambda: None)
+    resp = client.post("/data/generate")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert "started" in data["message"].lower()
+
+
+def test_train_returns_immediately(monkeypatch):
+    # Avoid running the heavy training logic during tests
+    monkeypatch.setattr("app.main.fit_elasticities", lambda: None)
+    resp = client.post("/models/train")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert "started" in data["message"].lower()


### PR DESCRIPTION
## Summary
- Run data generation and model training as FastAPI background tasks to avoid request timeouts
- Add tests ensuring these endpoints return immediately

## Testing
- `pytest -q tests/test_health.py tests/test_background_tasks.py tests/test_intents.py`


------
https://chatgpt.com/codex/tasks/task_e_68acc47afef8833081df32b7375ade5d