### PR TITLE
feat: use vertex ai gemini with google credentials

### DIFF
--- a/backend/app/agents/llm.py
+++ b/backend/app/agents/llm.py
@@ -1,7 +1,28 @@
 import os, json
 from typing import List, Dict, Any
 
+import vertexai
+from vertexai.generative_models import GenerativeModel, GenerationConfig
+
 from ..utils.secrets import get_gemini_api_key
+
+
+_MODEL_CACHE: Dict[str, GenerativeModel] = {}
+
+
+def _get_model(name: str, key: str) -> GenerativeModel:
+    """Initialize Vertex AI once and cache models for reuse."""
+    if name not in _MODEL_CACHE:
+        project = (
+            os.getenv("PROJECT_ID")
+            or os.getenv("GCP_PROJECT")
+            or os.getenv("GOOGLE_CLOUD_PROJECT")
+            or "dummy-project"
+        )
+        region = os.getenv("GCP_REGION") or os.getenv("REGION") or "us-central1"
+        vertexai.init(project=project, location=region, api_key=key)
+        _MODEL_CACHE[name] = GenerativeModel(name)
+    return _MODEL_CACHE[name]
 
 
 def _gemini_chat_json(messages, temperature, top_p, model=None):
@@ -9,16 +30,20 @@ def _gemini_chat_json(messages, temperature, top_p, model=None):
     key = get_gemini_api_key()
     if not key:
         raise RuntimeError("gemini_key_missing")
-    import google.generativeai as genai
-    genai.configure(api_key=key)
+
+    model_name = model or os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
+    mdl = _get_model(model_name, key)
 
     sys = "\n".join(m["content"] for m in messages if m["role"] == "system")
     usr = "\n".join(m["content"] for m in messages if m["role"] == "user")
     prompt = f"{sys}\n\n{usr}\n\nReturn ONLY valid JSON."
-    model_name = model or os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
-    r = genai.GenerativeModel(model_name).generate_content(
-        prompt, request_options={"timeout": 600}
+
+    cfg = GenerationConfig(
+        temperature=temperature,
+        top_p=top_p,
+        response_mime_type="application/json",
     )
+    r = mdl.generate_content(prompt, generation_config=cfg)
     text = (r.text or "{}").strip()
     start = text.find("{")
     if start != -1:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,5 +11,5 @@ jinja2==3.1.4
 httpx==0.27.2
 pyarrow==17.0.0
 sqlalchemy==2.0.32
-google-generativeai==0.8.3
+google-cloud-aiplatform==1.66.0
 google-cloud-secret-manager==2.20.2

--- a/ops/README.md
+++ b/ops/README.md
@@ -32,6 +32,7 @@ This command will:
 - **Pre-Built Prompts**: 8 business-ready prompt tiles for complex decisions
 - **Bounded Debates**: Maximum 3 rounds with automatic consensus generation
 - **Tool Integration**: Agents use optimization, simulation, and RAG tools
+- **Vertex AI Gemini**: Low-latency generation using API key from Google credentials
 
 ### 🔍 **RAG-Powered Insights**
 - **Table Search**: Query across all data tables with semantic similarity


### PR DESCRIPTION
## Summary
- switch agent and RAG calls to Vertex AI Gemini with cached models
- pull Gemini API key from Google credentials and streamline doc
- update requirements to include google-cloud-aiplatform

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc9a45db88330952115e7fcdbed0b