### PR TITLE
Resolve GCP project misconfiguration for Vertex AI

### DIFF
--- a/backend/app/agents/llm.py
+++ b/backend/app/agents/llm.py
@@ -1,10 +1,10 @@
 import os, json
 from typing import List, Dict, Any
 
-import vertexai
 from vertexai.generative_models import GenerativeModel, GenerationConfig
 
 from ..utils.secrets import get_gemini_api_key
+from ..utils.vertextai import init_vertexai
 
 
 _MODEL_CACHE: Dict[str, GenerativeModel] = {}
@@ -13,14 +13,7 @@ _MODEL_CACHE: Dict[str, GenerativeModel] = {}
 def _get_model(name: str, key: str) -> GenerativeModel:
     """Initialize Vertex AI once and cache models for reuse."""
     if name not in _MODEL_CACHE:
-        project = (
-            os.getenv("PROJECT_ID")
-            or os.getenv("GCP_PROJECT")
-            or os.getenv("GOOGLE_CLOUD_PROJECT")
-            or "dummy-project"
-        )
-        region = os.getenv("GCP_REGION") or os.getenv("REGION") or "us-central1"
-        vertexai.init(project=project, location=region, api_key=key)
+        init_vertexai(key)
         _MODEL_CACHE[name] = GenerativeModel(name)
     return _MODEL_CACHE[name]
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from .models.optimizer import run_optimizer
 from .rag.store import rag
 from .agents.orchestrator import agentic_huddle, agentic_huddle_v2
 from .utils.secrets import get_gemini_api_key
+from .utils.vertextai import init_vertexai
 from .bootstrap import bootstrap_if_needed
 import threading
 
@@ -99,7 +100,6 @@ def rag_search(q: str, topk: int = 4):
 @app.post("/genai/insight")
 def insight(payload: dict):
     import pandas as pd
-    import vertexai
     from vertexai.generative_models import GenerativeModel, GenerationConfig
 
     panel_id = payload.get("panel_id", "unknown")
@@ -110,14 +110,10 @@ def insight(payload: dict):
     if not api_key:
         return {"insight": "Gemini API key not configured."}
 
-    project = (
-        os.getenv("PROJECT_ID")
-        or os.getenv("GCP_PROJECT")
-        or os.getenv("GOOGLE_CLOUD_PROJECT")
-        or "dummy-project"
-    )
-    region = os.getenv("GCP_REGION") or os.getenv("REGION") or "us-central1"
-    vertexai.init(project=project, location=region, api_key=api_key)
+    try:
+        init_vertexai(api_key)
+    except Exception:
+        return {"insight": "GCP project ID not configured."}
     model = GenerativeModel(os.getenv("GEMINI_MODEL", "gemini-2.5-flash"))
 
     if data:

--- a/backend/app/rag/store.py
+++ b/backend/app/rag/store.py
@@ -7,7 +7,7 @@ from sklearn.metrics.pairwise import cosine_similarity
 from ..utils.io import engine
 from ..bootstrap import bootstrap_if_needed
 from ..utils.secrets import get_gemini_api_key
-import vertexai
+from ..utils.vertextai import init_vertexai
 from vertexai.language_models import TextEmbeddingModel
 
 try:
@@ -27,14 +27,7 @@ def _embed_texts(texts: List[str]) -> np.ndarray:
         key = get_gemini_api_key()
         if not key:
             raise Exception("No Gemini API key")
-        project = (
-            os.getenv("PROJECT_ID")
-            or os.getenv("GCP_PROJECT")
-            or os.getenv("GOOGLE_CLOUD_PROJECT")
-            or "dummy-project"
-        )
-        region = os.getenv("GCP_REGION") or os.getenv("REGION") or "us-central1"
-        vertexai.init(project=project, location=region, api_key=key)
+        init_vertexai(key)
         if _EMBED_MODEL is None:
             model_name = os.getenv("GEMINI_EMBED_MODEL", "text-embedding-004")
             _EMBED_MODEL = TextEmbeddingModel.from_pretrained(model_name)

--- a/backend/app/utils/gcp.py
+++ b/backend/app/utils/gcp.py
@@ -1,0 +1,19 @@
+import os
+import google.auth
+
+
+def get_project_id() -> str:
+    """Return the active GCP project ID or raise if missing."""
+    project = (
+        os.getenv("PROJECT_ID")
+        or os.getenv("GCP_PROJECT")
+        or os.getenv("GOOGLE_CLOUD_PROJECT")
+    )
+    if not project:
+        try:
+            _, project = google.auth.default()
+        except Exception:
+            project = None
+    if not project:
+        raise RuntimeError("gcp_project_missing")
+    return project

--- a/backend/app/utils/vertextai.py
+++ b/backend/app/utils/vertextai.py
@@ -1,0 +1,10 @@
+import os
+import vertexai
+from .gcp import get_project_id
+
+
+def init_vertexai(api_key: str | None = None) -> None:
+    """Initialize Vertex AI using configured project and region."""
+    project = get_project_id()
+    region = os.getenv("GCP_REGION") or os.getenv("REGION") or "us-central1"
+    vertexai.init(project=project, location=region, api_key=api_key)


### PR DESCRIPTION
## Summary
- Derive GCP project ID from environment or default credentials via new `get_project_id`
- Centralize Vertex AI initialization through new `init_vertexai` helper
- Use the helper for Vertex AI calls in LLM, insight endpoint, and RAG store

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acd1cd49488330a3a2b4137fd7dcb4