### PR TITLE
chore: lazy load pages and trim dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,13 +3,11 @@ uvicorn==0.30.6
 pandas==2.2.2
 numpy==1.26.4
 scikit-learn==1.4.2
-statsmodels==0.14.2
 pulp==2.7.0
 python-multipart==0.0.9
 pydantic==2.8.2
 jinja2==3.1.4
 httpx==0.27.2
-pyarrow==17.0.0
 sqlalchemy==2.0.32
 google-cloud-aiplatform==1.66.0
 google-cloud-secret-manager==2.20.2

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,17 +6,18 @@ import { BrowserRouter, Routes, Route, Link, useLocation } from "react-router-do
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Home, DollarSign, TrendingUp, Package, Settings, Zap, Search, FileText, Menu } from "lucide-react";
-import Landing from "./pages/Landing";
-import PPA from "./pages/PPA";
-import Elasticities from "./pages/Elasticities";
-import Assortment from "./pages/Assortment";
-import Simulator from "./pages/Simulator";
-import Optimizer from "./pages/Optimizer";
-import Huddle from "./pages/Huddle";
-import RAG from "./pages/RAG";
-import RAGSearch from "./pages/RAGSearch";
-import Decisions from "./pages/Decisions";
-import NotFound from "./pages/NotFound";
+import { lazy, Suspense } from "react";
+
+const Landing = lazy(() => import("./pages/Landing"));
+const PPA = lazy(() => import("./pages/PPA"));
+const Elasticities = lazy(() => import("./pages/Elasticities"));
+const Assortment = lazy(() => import("./pages/Assortment"));
+const Simulator = lazy(() => import("./pages/Simulator"));
+const Optimizer = lazy(() => import("./pages/Optimizer"));
+const Huddle = lazy(() => import("./pages/Huddle"));
+const RAGSearch = lazy(() => import("./pages/RAGSearch"));
+const Decisions = lazy(() => import("./pages/Decisions"));
+const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = new QueryClient();
 
@@ -84,21 +85,23 @@ const App = () => (
             <aside className="hidden lg:block">
               <Navigation />
             </aside>
-            
+
             {/* Main Content */}
             <main className="min-h-screen">
-              <Routes>
-                <Route path="/" element={<Landing />} />
-                <Route path="/ppa" element={<PPA />} />
-                <Route path="/elasticities" element={<Elasticities />} />
-                <Route path="/assortment" element={<Assortment />} />
-                <Route path="/simulator" element={<Simulator />} />
-                <Route path="/optimizer" element={<Optimizer />} />
-                <Route path="/huddle" element={<Huddle />} />
-                <Route path="/rag" element={<RAGSearch />} />
-                <Route path="/decisions" element={<Decisions />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
+              <Suspense fallback={<div className="p-4">Loading...</div>}>
+                <Routes>
+                  <Route path="/" element={<Landing />} />
+                  <Route path="/ppa" element={<PPA />} />
+                  <Route path="/elasticities" element={<Elasticities />} />
+                  <Route path="/assortment" element={<Assortment />} />
+                  <Route path="/simulator" element={<Simulator />} />
+                  <Route path="/optimizer" element={<Optimizer />} />
+                  <Route path="/huddle" element={<Huddle />} />
+                  <Route path="/rag" element={<RAGSearch />} />
+                  <Route path="/decisions" element={<Decisions />} />
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </Suspense>
             </main>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- lazy-load each UI route with `React.lazy` and `Suspense`
- drop unused heavy Python packages to streamline backend image

## Testing
- `npm test`
- `npm run build`
- `pytest backend/tests/test_intents.py`
- `pytest backend/tests/test_health.py`
- `pytest backend/tests/test_background_tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68accd9ab368833086968b500f9d1e42