### PR TITLE
Remove client fallbacks and clarify optimizer rounds

### DIFF
--- a/src/components/AgenticHuddle.tsx
+++ b/src/components/AgenticHuddle.tsx
@@ -423,7 +423,7 @@ export default function AgenticHuddle() {
           
           {resp?.error && (
             <div className="text-xs text-amber-700 mt-1">
-              Engine notes: {resp.error}
+              Some data sources were unavailable; results may be limited.
             </div>
           )}
           
@@ -438,49 +438,55 @@ export default function AgenticHuddle() {
             </div>
           )}
 
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm bg-background/10 rounded-lg">
-              <thead>
-                <tr className="text-left border-b border-primary-foreground/20">
-                  <th className="p-3 text-primary-foreground font-medium">Action</th>
-                  <th className="p-3 text-primary-foreground font-medium">Targets</th>
-                  <th className="p-3 text-primary-foreground font-medium">Δ%</th>
-                  <th className="p-3 text-primary-foreground font-medium">Impact (U/Rev/Mgn)</th>
-                  <th className="p-3 text-primary-foreground font-medium">Risks</th>
-                  <th className="p-3 text-primary-foreground font-medium">Confidence</th>
-                </tr>
-              </thead>
-              <tbody>
-                {FinalPlan.actions?.map((a, i) => (
-                  <tr key={i} className="border-t border-primary-foreground/10">
-                    <td className="p-3 text-primary-foreground/90 font-medium">
-                      {a.action_type.replace('_', ' ')}
-                    </td>
-                    <td className="p-3 text-primary-foreground/80">
-                      <div>{a.target_type}</div>
-                      <div className="text-xs text-primary-foreground/60">
-                        {a.ids?.join(", ")}
-                      </div>
-                    </td>
-                    <td className="p-3 text-primary-foreground/90 font-mono">
-                      {(a.magnitude_pct * 100).toFixed(1)}%
-                    </td>
-                    <td className="p-3 text-primary-foreground/80 text-xs">
-                      <div>U: {a.expected_impact?.units?.toFixed(0) ?? "-"}</div>
-                      <div>Rev: {a.expected_impact?.revenue?.toFixed(0) ?? "-"}</div>
-                      <div>Mgn: {a.expected_impact?.margin?.toFixed(0) ?? "-"}</div>
-                    </td>
-                    <td className="p-3 text-primary-foreground/70 text-xs max-w-48">
-                      {a.risks?.slice(0, 2).join("; ") || "-"}
-                    </td>
-                    <td className="p-3 text-primary-foreground/90 font-mono">
-                      {(a.confidence ?? 0).toFixed(2)}
-                    </td>
+          {FinalPlan.actions && FinalPlan.actions.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm bg-background/10 rounded-lg">
+                <thead>
+                  <tr className="text-left border-b border-primary-foreground/20">
+                    <th className="p-3 text-primary-foreground font-medium">Action</th>
+                    <th className="p-3 text-primary-foreground font-medium">Targets</th>
+                    <th className="p-3 text-primary-foreground font-medium">Δ%</th>
+                    <th className="p-3 text-primary-foreground font-medium">Impact (U/Rev/Mgn)</th>
+                    <th className="p-3 text-primary-foreground font-medium">Risks</th>
+                    <th className="p-3 text-primary-foreground font-medium">Confidence</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {FinalPlan.actions.map((a, i) => (
+                    <tr key={i} className="border-t border-primary-foreground/10">
+                      <td className="p-3 text-primary-foreground/90 font-medium">
+                        {a.action_type.replace('_', ' ')}
+                      </td>
+                      <td className="p-3 text-primary-foreground/80">
+                        <div>{a.target_type}</div>
+                        <div className="text-xs text-primary-foreground/60">
+                          {a.ids?.join(", ")}
+                        </div>
+                      </td>
+                      <td className="p-3 text-primary-foreground/90 font-mono">
+                        {(a.magnitude_pct * 100).toFixed(1)}%
+                      </td>
+                      <td className="p-3 text-primary-foreground/80 text-xs">
+                        <div>U: {a.expected_impact?.units?.toFixed(0) ?? "-"}</div>
+                        <div>Rev: {a.expected_impact?.revenue?.toFixed(0) ?? "-"}</div>
+                        <div>Mgn: {a.expected_impact?.margin?.toFixed(0) ?? "-"}</div>
+                      </td>
+                      <td className="p-3 text-primary-foreground/70 text-xs max-w-48">
+                        {a.risks?.slice(0, 2).join("; ") || "-"}
+                      </td>
+                      <td className="p-3 text-primary-foreground/90 font-mono">
+                        {(a.confidence ?? 0).toFixed(2)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="text-sm text-primary-foreground/80">
+              No actions returned in the final plan.
+            </div>
+          )}
 
           {FinalPlan.rationale && (
             <div className="mt-4 p-3 bg-background/10 rounded-lg">

--- a/src/components/ChartWithInsight.tsx
+++ b/src/components/ChartWithInsight.tsx
@@ -30,32 +30,12 @@ const ChartWithInsight: React.FC<ChartWithInsightProps> = ({
       setInsight(resp.insight);
       setShowInsight(true);
     } catch (error) {
-      console.error('Insight generation failed, using fallback:', error);
-      const mockInsight = generateMockInsight(panelId, title);
-      setInsight(mockInsight);
+      console.error('Insight generation failed:', error);
+      setInsight('Unable to generate insight.');
       setShowInsight(true);
     } finally {
       setLoading(false);
     }
-  };
-
-  const generateMockInsight = (panelId: string, title: string) => {
-    const insights = {
-      'revenue-trend': 'Revenue shows strong upward momentum with 12% growth over the past 8 weeks. The trend indicates successful pricing strategies and market expansion, with margin improvements suggesting operational efficiency gains.',
-      'channel-mix': 'Modern Trade dominates with 45% share, reflecting strong retail partnerships. eCom growth (20%) presents expansion opportunities, while General Trade maintains stable 35% contribution.',
-      'brand-performance': 'Aurel leads revenue generation at ₹3.2Cr but Lumio shows highest margin efficiency at 25.2%. Verra demonstrates strong premium positioning with sustainable profitability.',
-      'price-ladder': 'Price ladder shows logical progression from ₹1.95 to ₹5.75. 330ml-500ml gap presents opportunity for 375ml premium variant. PPM efficiency decreases with larger formats.',
-      'ppm-analysis': 'Premium tier maintains 15-20% price premium across pack sizes. Core variants show competitive positioning vs market. 1L+ formats offer margin expansion opportunities.',
-      'whitespace-matrix': '375ml and 750ml gaps identified as high-potential opportunities. Score >85 indicates strong feasibility. Manufacturing complexity needs evaluation for new formats.',
-      'attribute-importance': 'Price drives 34% of demand variance, followed by brand equity (28%). Pack size influences 18% of purchase decisions. Sugar-free variants show growing importance.',
-      'promo-uplift': 'Optimal promotion depth is 15-20% for maximum ROI. Beyond 25% depth shows diminishing returns. Baseline volume resilience indicates strong brand equity.',
-      'seasonality': 'Peak demand in October (35% uplift) driven by festival season. Summer months show 25% increase. Winter dip suggests category seasonality patterns.',
-      'volume-trend': 'Volume recovery post price increases indicates inelastic segments. Week-over-week stability suggests successful demand planning and market acceptance.',
-      'margin-trend': 'Margin expansion driven by strategic pricing and operational improvements. 15% quarter-over-quarter growth exceeds category benchmarks.',
-      'default': `${title} analysis reveals key performance drivers and optimization opportunities. Data patterns suggest strategic focus areas for continued growth and profitability improvements.`
-    };
-    
-    return insights[panelId as keyof typeof insights] || insights.default;
   };
 
   return (

--- a/src/components/OptimizerView.tsx
+++ b/src/components/OptimizerView.tsx
@@ -29,6 +29,11 @@ const OptimizerView: React.FC = () => {
   const [result, setResult] = useState<OptimizerResult | null>(null);
   const [loading, setLoading] = useState(false);
 
+  useEffect(() => {
+    // Clear previous results when switching rounds
+    setResult(null);
+  }, [round]);
+
   const runOptimization = async () => {
     setLoading(true);
     try {
@@ -36,22 +41,7 @@ const OptimizerView: React.FC = () => {
       setResult(response.data);
     } catch (error) {
       console.error('Optimization failed:', error);
-      // Mock result for demo
-      setResult({
-        solution: [
-          { sku_id: 1001, brand: 'Aurel', pct_change: 0.08, near_bound: 0, new_price: 2.43, margin: 1250, p0: 2.25 },
-          { sku_id: 1002, brand: 'Novis', pct_change: -0.05, near_bound: 0, new_price: 3.14, margin: 2100, p0: 3.30 },
-          { sku_id: 1003, brand: 'Verra', pct_change: 0.15, near_bound: 1, new_price: 4.89, margin: 3200, p0: 4.25 },
-          { sku_id: 1004, brand: 'Kairo', pct_change: 0.12, near_bound: 0, new_price: 3.92, margin: 1800, p0: 3.50 },
-          { sku_id: 1005, brand: 'Lumio', pct_change: -0.02, near_bound: 0, new_price: 5.39, margin: 4100, p0: 5.50 },
-        ],
-        kpis: {
-          status: 'Optimal',
-          n_near_bound: 1,
-          rev: 12450000,
-          margin: 3890000
-        }
-      });
+      setResult(null);
     } finally {
       setLoading(false);
     }

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -42,61 +42,7 @@ const Simulator: React.FC = () => {
       setSimulationResult(response.data);
     } catch (error) {
       console.error('Simulation failed:', error);
-      // Calculate elasticity-based impact for demo
-      let totalVolumeImpact = 0;
-      let totalRevenueImpact = 0;
-      let totalMarginImpact = 0;
-      
-      skus.forEach((sku, idx) => {
-        const change_i = priceChanges[sku.id] || 0;
-        if (change_i !== 0 || Object.values(priceChanges).some(v => v !== 0)) {
-          // Own + Cross elasticity volume impact for SKU i
-          const ownImpact = sku.elasticity * change_i;
-
-          // Cross elasticities by brand (negative treated as 0 = no substitution)
-          const crossElasticities: Record<string, Record<string, number>> = {
-            Aurel: { Novis: 0.12, Verra: 0.09, Kairo: 0, Lumio: 0.13 },
-            Novis: { Aurel: 0.15, Verra: 0, Kairo: 0.18, Lumio: 0 },
-            Verra: { Lumio: 0.22, Aurel: 0.09, Novis: 0, Kairo: 0 },
-            Kairo: { Novis: 0.14, Verra: 0.11, Aurel: 0, Lumio: 0.16 },
-            Lumio: { Kairo: 0.16, Aurel: 0.13, Novis: 0, Verra: 0.22 },
-          };
-
-          const crossImpact = skus.reduce((acc, other) => {
-            if (other.id === sku.id) return acc;
-            const pc_j = priceChanges[other.id] || 0;
-            if (pc_j === 0) return acc;
-            const e_ij = Math.max(0, crossElasticities[sku.brand]?.[other.brand] ?? 0);
-            return acc + e_ij * pc_j;
-          }, 0);
-
-          const volumeImpact = ownImpact + crossImpact;
-          // Revenue impact includes price and volume effects
-          const revenueImpact = change_i + volumeImpact;
-          // Margin impact is amplified due to leverage
-          const marginImpact = revenueImpact * 1.8;
-
-          // Equal weighting across SKUs (placeholder for contribution weights)
-          const weight = 1 / skus.length;
-          totalVolumeImpact += volumeImpact * weight;
-          totalRevenueImpact += revenueImpact * weight;
-          totalMarginImpact += marginImpact * weight;
-        }
-      });
-
-      setSimulationResult({
-        agg: [
-          { week: 1, units: 85000 * (1 + totalVolumeImpact), revenue: 12400000 * (1 + totalRevenueImpact), margin: 3100000 * (1 + totalMarginImpact) },
-          { week: 2, units: 87200 * (1 + totalVolumeImpact), revenue: 12750000 * (1 + totalRevenueImpact), margin: 3250000 * (1 + totalMarginImpact) },
-          { week: 3, units: 84500 * (1 + totalVolumeImpact), revenue: 12600000 * (1 + totalRevenueImpact), margin: 3180000 * (1 + totalMarginImpact) },
-          { week: 4, units: 88900 * (1 + totalVolumeImpact), revenue: 13100000 * (1 + totalRevenueImpact), margin: 3420000 * (1 + totalMarginImpact) },
-        ],
-        summary: {
-          volume_change: totalVolumeImpact * 100,
-          revenue_change: totalRevenueImpact * 100,
-          margin_change: totalMarginImpact * 100
-        }
-      });
+      setSimulationResult(null);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- drop mock GenAI insights; surface failure message instead
- clear and rerun optimizer per round without demo fallback data
- remove client-side simulation heuristics so results come only from backend
- hide empty final plan table in Agentic AI Huddle
- show concise warning instead of raw engine notes in final plan
- fall back to CSV when parquet engines are missing during data generation

## Testing
- `npm test -- --run`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b151ee3f108330b1c5406e71cd70c3