### PR TITLE
Show KPI deltas in price optimizer

### DIFF
--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -77,10 +77,14 @@ def agentic_huddle_v2(
 ) -> Dict[str, Any]:
     # Hard cap to 3 rounds of debate to keep deliberation bounded
     debate_rounds = min(debate_rounds, 3)
-    hits = rag.query(question, topk=4)
+    error_msg: str | None = None
+    try:
+        hits = rag.query(question, topk=4)
+    except Exception:
+        hits = []
+        error_msg = "Some data sources were unavailable; results may be limited."
     context = [h["text"] for h in hits]
     transcript: List[Dict[str, Any]] = []
-    error_msg: str | None = None
     candidates: List[Dict[str, Any]] = []
 
     try:

--- a/backend/app/models/optimizer.py
+++ b/backend/app/models/optimizer.py
@@ -126,11 +126,25 @@ def run_optimizer(max_pct_change_round1=0.20, max_pct_change_round2=0.40, spend_
     sol["new_price"] = sol["p0"] * (1+sol["pct_change"])
     sol["new_units"] = sol["base_units"] * (1 + sol["own_elast"]*sol["pct_change"])
     sol["margin"] = (sol["new_price"] - (sol["cogs_per_unit"]+sol["logistics_per_unit"])) * sol["new_units"]
+    rev_base = float((sol["p0"] * sol["base_units"]).sum())
+    margin_base = float(
+        (
+            sol["p0"]
+            - (sol["cogs_per_unit"] + sol["logistics_per_unit"])
+        )
+        * sol["base_units"]
+    )
+    rev_new = float((sol["new_price"] * sol["new_units"]).sum())
+    margin_new = float(sol["margin"].sum())
     kpis = {
         "status": LpStatus[M.status],
         "n_near_bound": int(sol.near_bound.sum()),
-        "rev": float((sol["new_price"]*sol["new_units"]).sum()),
-        "margin": float(sol["margin"].sum()),
+        "rev": rev_new,
+        "margin": margin_new,
+        "rev_base": rev_base,
+        "margin_base": margin_base,
+        "rev_delta": rev_new - rev_base,
+        "margin_delta": margin_new - margin_base,
     }
     return sol.to_dict(orient="records"), kpis
 
@@ -167,11 +181,26 @@ def _heuristic_optimizer(max_change=0.20):
     df["new_price"] = df["p0"] * (1 + df["pct_change"])
     df["new_units"] = df["base_units"] * (1 + df["own_elast"] * df["pct_change"])
     df["margin"] = (df["new_price"] - (df["cogs_per_unit"] + df["logistics_per_unit"])) * df["new_units"]
-    
+
+    rev_base = float((df["p0"] * df["base_units"]).sum())
+    margin_base = float(
+        (
+            df["p0"]
+            - (df["cogs_per_unit"] + df["logistics_per_unit"])
+        )
+        * df["base_units"]
+    )
+    rev_new = float((df["new_price"] * df["new_units"]).sum())
+    margin_new = float(df["margin"].sum())
+
     kpis = {
         "status": "Optimal",
         "n_near_bound": 0,
-        "rev": float((df["new_price"] * df["new_units"]).sum()),
-        "margin": float(df["margin"].sum()),
+        "rev": rev_new,
+        "margin": margin_new,
+        "rev_base": rev_base,
+        "margin_base": margin_base,
+        "rev_delta": rev_new - rev_base,
+        "margin_delta": margin_new - margin_base,
     }
     return df.to_dict(orient="records"), kpis

--- a/backend/tests/test_huddle_smoke.py
+++ b/backend/tests/test_huddle_smoke.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import pandas as pd
+from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 # Ensure the app package is importable
@@ -8,11 +10,46 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_huddle_smoke():
     payload = {"q": "How can we improve margins?", "budget": 1000}
-    resp = client.post("/huddle/run", json=payload)
+
+    # Minimal optimizer tables for a single SKU
+    tiny_tables = (
+        pd.DataFrame({"sku_id": [1], "week": [1], "net_price": [10.0]}),
+        pd.DataFrame({"sku_id": [1], "week": [1], "units": [100.0]}),
+        pd.DataFrame({"sku_id": [1], "cogs_per_unit": [6.0], "logistics_per_unit": [1.0]}),
+        pd.DataFrame({"sku_id": [1], "floor": [8.0], "ceiling": [12.0]}),
+        pd.DataFrame({"sku_id": [1], "own_elast": [-1.0]}),
+    )
+
+    def rag_fail(*args, **kwargs):
+        raise Exception("offline")
+
+    def fake_chat_json(*args, **kwargs):
+        raise TimeoutError("llm timeout")
+
+    dummy_agg = pd.DataFrame([{"units": 100, "revenue": 1000, "margin": 200}])
+
+    def fake_sim_price(changes):
+        return dummy_agg, pd.DataFrame([{"sku_id": 1}])
+
+    def fake_sim_delist(ids):
+        return pd.DataFrame()
+
+    with (
+        patch("app.agents.orchestrator.rag.query", rag_fail),
+        patch("app.agents.orchestrator.chat_json", fake_chat_json),
+        patch("app.models.optimizer._load_tables", return_value=tiny_tables),
+        patch("app.models.scorer.simulate_price_change", fake_sim_price),
+        patch("app.models.scorer.simulate_delist", fake_sim_delist),
+        patch.dict(os.environ, {"OPTIMIZER_MAX_SKUS": "1", "OPTIMIZER_TIME_LIMIT": "5"}, clear=False),
+    ):
+        resp = client.post("/huddle/run", json=payload)
+
     assert resp.status_code == 200
     data = resp.json()
-    assert "final" in data
-    assert data["final"]["plan_name"] in {"Optimizer-backed fallback", "Optimizer fallback"}
+    assert data["final"]["plan_name"] == "Optimizer-backed fallback"
+    assert "LLM unavailable or timed out" in data["final"]["rationale"]
+    assert "Some data sources were unavailable" in data.get("error", "")
 

--- a/backend/tests/test_simulation_optimize_smoke.py
+++ b/backend/tests/test_simulation_optimize_smoke.py
@@ -21,9 +21,20 @@ def test_simulate_price_smoke(monkeypatch):
 
 
 def test_optimize_run_smoke(monkeypatch):
-    monkeypatch.setattr("app.main.run_optimizer", lambda round=1: ([{"sku_id": 1}], {"margin": 10}))
+    dummy_kpis = {
+        "status": "Optimal",
+        "n_near_bound": 0,
+        "rev": 100,
+        "margin": 10,
+        "rev_base": 90,
+        "margin_base": 8,
+        "rev_delta": 10,
+        "margin_delta": 2,
+    }
+    monkeypatch.setattr("app.main.run_optimizer", lambda round=1: ([{"sku_id": 1}], dummy_kpis))
     resp = client.post("/optimize/run")
     assert resp.status_code == 200
     data = resp.json()
     assert data["solution"][0]["sku_id"] == 1
-    assert "margin" in data["kpis"]
+    for key in dummy_kpis:
+        assert key in data["kpis"]

--- a/src/components/OptimizerView.tsx
+++ b/src/components/OptimizerView.tsx
@@ -21,6 +21,10 @@ interface OptimizerResult {
     n_near_bound: number;
     rev: number;
     margin: number;
+    rev_base: number;
+    margin_base: number;
+    rev_delta: number;
+    margin_delta: number;
   };
 }
 
@@ -141,11 +145,19 @@ const OptimizerView: React.FC = () => {
                 <TrendingUp className="h-5 w-5 text-success" />
                 <h4 className="font-semibold text-foreground">Revenue Impact</h4>
               </div>
-              <div className="text-2xl font-bold text-foreground mb-2">
-                {formatCurrency(result.kpis.rev)}
+              <div className="text-2xl font-bold text-foreground mb-2 flex items-baseline space-x-2">
+                <span>{formatCurrency(result.kpis.rev)}</span>
+                <span
+                  className={`text-sm ${
+                    result.kpis.rev_delta >= 0 ? 'text-success' : 'text-destructive'
+                  }`}
+                >
+                  {result.kpis.rev_delta >= 0 ? '+' : ''}
+                  {formatCurrency(result.kpis.rev_delta)}
+                </span>
               </div>
               <p className="text-sm text-muted-foreground">
-                Projected revenue after optimization
+                Baseline: {formatCurrency(result.kpis.rev_base)}
               </p>
             </Card>
             
@@ -154,11 +166,19 @@ const OptimizerView: React.FC = () => {
                 <CheckCircle className="h-5 w-5 text-success" />
                 <h4 className="font-semibold text-foreground">Margin Improvement</h4>
               </div>
-              <div className="text-2xl font-bold text-foreground mb-2">
-                {formatCurrency(result.kpis.margin)}
+              <div className="text-2xl font-bold text-foreground mb-2 flex items-baseline space-x-2">
+                <span>{formatCurrency(result.kpis.margin)}</span>
+                <span
+                  className={`text-sm ${
+                    result.kpis.margin_delta >= 0 ? 'text-success' : 'text-destructive'
+                  }`}
+                >
+                  {result.kpis.margin_delta >= 0 ? '+' : ''}
+                  {formatCurrency(result.kpis.margin_delta)}
+                </span>
               </div>
               <p className="text-sm text-muted-foreground">
-                Total margin after price changes
+                Baseline: {formatCurrency(result.kpis.margin_base)}
               </p>
             </Card>
           </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -50,6 +50,10 @@ export interface OptimizationResult {
     n_near_bound: number;
     rev: number;
     margin: number;
+    rev_base: number;
+    margin_base: number;
+    rev_delta: number;
+    margin_delta: number;
   };
 }
 


### PR DESCRIPTION
## Summary
- compute baseline revenue and margin in optimizer and return KPI deltas
- expose KPI deltas in API and OptimizerView UI
- extend smoke test to cover new KPI fields
- run huddle smoke test with lightweight RAG, LLM, and optimizer pieces to exercise the full path
- surface fallback plan when data sources or LLM are unavailable to keep huddle flows responsive

## Testing
- `npm test -- --run`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b15a5d93208330bc12629ce887a217