### PR TITLE
Fix delist KPI volume and baseline margin computation

### DIFF
--- a/backend/app/models/optimizer.py
+++ b/backend/app/models/optimizer.py
@@ -125,10 +125,12 @@ def _run_optimizer_pulp(max_pct_change_round1=0.20, max_pct_change_round2=0.40, 
     rev_base = float((sol["p0"] * sol["base_units"]).sum())
     margin_base = float(
         (
-            sol["p0"]
-            - (sol["cogs_per_unit"] + sol["logistics_per_unit"])
-        )
-        * sol["base_units"]
+            (
+                sol["p0"]
+                - (sol["cogs_per_unit"] + sol["logistics_per_unit"])
+            )
+            * sol["base_units"]
+        ).sum()
     )
     rev_new = float((sol["new_price"] * sol["new_units"]).sum())
     margin_new = float(sol["margin"].sum())
@@ -192,10 +194,12 @@ def _heuristic_optimizer(max_change=0.20):
     rev_base = float((df["p0"] * df["base_units"]).sum())
     margin_base = float(
         (
-            df["p0"]
-            - (df["cogs_per_unit"] + df["logistics_per_unit"])
-        )
-        * df["base_units"]
+            (
+                df["p0"]
+                - (df["cogs_per_unit"] + df["logistics_per_unit"])
+            )
+            * df["base_units"]
+        ).sum()
     )
     rev_new = float((df["new_price"] * df["new_units"]).sum())
     margin_new = float(df["margin"].sum())

--- a/backend/app/models/scorer.py
+++ b/backend/app/models/scorer.py
@@ -57,9 +57,14 @@ def evaluate_plan(plan: Dict[str, Any]) -> Tuple[Dict[str, float], Dict[str, int
     if delists:
         keep = simulate_delist(delists)
         if not keep.empty:
-            kpi_total["units"] += float(keep["units"].sum())
-            kpi_total["revenue"] += float((keep["units"] * 1.0).sum())
-            kpi_total["margin"] += float((keep.get("units",0) * 0.2).sum())
+            units_series = (
+                keep["new_units"]
+                if "new_units" in keep.columns
+                else keep.get("units", pd.Series(dtype=float))
+            )
+            kpi_total["units"] += float(units_series.sum())
+            kpi_total["revenue"] += float((units_series * 1.0).sum())
+            kpi_total["margin"] += float((units_series * 0.2).sum())
 
     n_actions = len(plan.get("actions", []))
     risk_pen = 0.02 * near_bound_hits + 0.005 * n_actions


### PR DESCRIPTION
## Summary
- honor redistributed `new_units` when scoring delist plans
- sum baseline margin series in optimizer paths to avoid casting errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b171e3e5088330b1a85d1c89f73266