### PR TITLE
Optimize elasticity simulations for faster huddles

### DIFF
--- a/backend/app/models/scorer.py
+++ b/backend/app/models/scorer.py
@@ -1,10 +1,12 @@
 from typing import Dict, List, Tuple, Any
+from functools import lru_cache
 import pandas as pd
 import numpy as np
 from ..utils.io import engine
 from ..bootstrap import bootstrap_if_needed
 from ..models.simulator import simulate_price_change, simulate_delist
 
+@lru_cache()
 def _latest_price_and_base():
     bootstrap_if_needed()
     con = engine().connect()


### PR DESCRIPTION
## Summary
- cache merged simulation data so agentic huddles and optimizers reuse elasticity inputs without repeated joins
- compute price simulations purely from elasticity factors without truncating units, keeping cost handling consistent
- memoize the latest baseline used for plan impact annotations to avoid redundant queries during huddle scoring

## Testing
- pytest backend

------
https://chatgpt.com/codex/tasks/task_e_68df679c5f988330be86916a45553c34