### PR TITLE
Improve KPI display precision

### DIFF
--- a/backend/app/models/optimizer.py
+++ b/backend/app/models/optimizer.py
@@ -51,7 +51,8 @@ def _run_optimizer_pulp(max_pct_change_round1=0.20, max_pct_change_round2=0.40, 
         .merge(guard, on="sku_id")
         .merge(elast, on="sku_id", how="left")
     )
-    df["own_elast"].fillna(-1.0, inplace=True)
+    df["own_elast"] = df["own_elast"].fillna(-1.0)
+    df.loc[df["own_elast"].abs() < 1e-4, "own_elast"] = -1.0
 
     max_skus = int(os.getenv("OPTIMIZER_MAX_SKUS", "200"))
     if len(df) > max_skus:
@@ -180,7 +181,8 @@ def _heuristic_optimizer(max_change=0.20):
         .merge(costs, on="sku_id")
         .merge(elast, on="sku_id", how="left")
     )
-    df["own_elast"].fillna(-1.0, inplace=True)
+    df["own_elast"] = df["own_elast"].fillna(-1.0)
+    df.loc[df["own_elast"].abs() < 1e-4, "own_elast"] = -1.0
 
     max_skus = int(os.getenv("OPTIMIZER_MAX_SKUS", "200"))
     if len(df) > max_skus:

--- a/backend/app/models/scorer.py
+++ b/backend/app/models/scorer.py
@@ -19,6 +19,7 @@ def _latest_price_and_base():
     u = demand[demand.week>=recent_w-8].groupby("sku_id").units.mean().rename("u0")
     df = pd.concat([p, u], axis=1).reset_index().merge(costs, on="sku_id", how="left").merge(elast, on="sku_id", how="left")
     df["own_elast"] = df["own_elast"].fillna(-1.0)
+    df.loc[df["own_elast"].abs() < 1e-4, "own_elast"] = -1.0
     return df
 
 def evaluate_plan(plan: Dict[str, Any]) -> Tuple[Dict[str, float], Dict[str, int]]:

--- a/backend/app/models/simulator.py
+++ b/backend/app/models/simulator.py
@@ -42,6 +42,10 @@ def _price_simulation_frame() -> pd.DataFrame:
         .merge(sku[["sku_id", "brand"]], on="sku_id", how="left")
     )
     df["own_elast"] = df["own_elast"].fillna(-1.0)
+    # Some synthetic elasticities can be exactly zero when the regression
+    # fallback fails.  Treat near-zero values as missing so simulations still
+    # react to price changes instead of showing 0% impact across the UI.
+    df.loc[df["own_elast"].abs() < 1e-4, "own_elast"] = -1.0
     df["cost_per_unit"] = df["cogs_per_unit"].fillna(0.0) + df["logistics_per_unit"].fillna(0.0)
     return df
 

--- a/src/components/OptimizerView.tsx
+++ b/src/components/OptimizerView.tsx
@@ -54,7 +54,62 @@ const OptimizerView: React.FC = () => {
     }
   };
 
-  const formatCurrency = (value: number) => `₹${(value / 1000000).toFixed(1)}M`;
+  const formatCurrency = (value: number) => {
+    if (!Number.isFinite(value)) {
+      return '₹0';
+    }
+
+    const abs = Math.abs(value);
+    const sign = value < 0 ? '-' : '';
+    const withSuffix = (divisor: number, suffix: string, decimals: number) =>
+      `${sign}₹${(abs / divisor).toFixed(decimals)}${suffix}`;
+
+    if (abs === 0) {
+      return '₹0';
+    }
+
+    if (abs < 0.01) {
+      return `${sign}<₹0.01`;
+    }
+
+    if (abs < 1) {
+      return `${sign}₹${abs.toFixed(2)}`;
+    }
+
+    if (abs < 10) {
+      return `${sign}₹${abs.toFixed(2)}`;
+    }
+
+    if (abs < 100) {
+      return `${sign}₹${abs.toFixed(1)}`;
+    }
+
+    if (abs < 1000) {
+      return `${sign}₹${abs.toFixed(0)}`;
+    }
+
+    if (abs < 10000) {
+      return withSuffix(1000, 'K', 2);
+    }
+
+    if (abs < 100000) {
+      return withSuffix(1000, 'K', 1);
+    }
+
+    if (abs < 1000000) {
+      return withSuffix(1000, 'K', 0);
+    }
+
+    if (abs < 10000000) {
+      return withSuffix(1000000, 'M', 2);
+    }
+
+    if (abs < 1000000000) {
+      return withSuffix(1000000, 'M', 1);
+    }
+
+    return withSuffix(1000000000, 'B', 2);
+  };
   const formatPercent = (value: number) => `${(value * 100).toFixed(1)}%`;
   const formatUnits = (value: number) => value.toLocaleString();
 

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -54,8 +54,23 @@ const Simulator: React.FC = () => {
   };
 
   const formatPercent = (value: number) => {
-    const sign = value >= 0 ? '+' : '';
-    return `${sign}${value.toFixed(1)}%`;
+    if (!Number.isFinite(value)) {
+      return '0.0%';
+    }
+
+    if (value === 0) {
+      return '0.0%';
+    }
+
+    const sign = value > 0 ? '+' : value < 0 ? '-' : '';
+    const abs = Math.abs(value);
+
+    if (abs < 0.01) {
+      return `${sign}<0.01%`;
+    }
+
+    const decimals = abs < 1 ? 2 : 1;
+    return `${sign}${abs.toFixed(decimals)}%`;
   };
 
   const getElasticityColor = (elasticity: number) => {


### PR DESCRIPTION
## Summary
- treat near-zero elasticity estimates as missing in the simulator so price changes adjust volume
- apply the same fallback in optimizer and agent scoring flows to surface revenue and margin impact
- format simulator and optimizer KPIs so sub-percent and small-currency moves render instead of showing zero impact

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68df74d9223083309fa1ff9cf1c46db1