### PR TITLE
Fix KPI deltas for price change simulations

### DIFF
--- a/backend/app/models/scorer.py
+++ b/backend/app/models/scorer.py
@@ -52,10 +52,14 @@ def evaluate_plan(plan: Dict[str, Any]) -> Tuple[Dict[str, float], Dict[str, int
 
     kpi_total = {"units": 0.0, "revenue": 0.0, "margin": 0.0}
     if pct_changes:
-        agg, _ = simulate_price_change({k: v for k,v in pct_changes.items()})
-        kpi_total["units"] += float(agg["units"].mean())
-        kpi_total["revenue"] += float(agg["revenue"].mean())
-        kpi_total["margin"] += float(agg["margin"].mean())
+        agg, _ = simulate_price_change({k: v for k, v in pct_changes.items()})
+        if not agg.empty:
+            units_delta = agg["units"] - agg.get("base_units", 0.0)
+            revenue_delta = agg["revenue"] - agg.get("base_revenue", 0.0)
+            margin_delta = agg["margin"] - agg.get("base_margin", 0.0)
+            kpi_total["units"] += float(units_delta.mean())
+            kpi_total["revenue"] += float(revenue_delta.mean())
+            kpi_total["margin"] += float(margin_delta.mean())
 
     if delists:
         keep = simulate_delist(delists)

--- a/backend/app/models/simulator.py
+++ b/backend/app/models/simulator.py
@@ -87,10 +87,19 @@ def simulate_price_change(sku_pct_changes: dict, weeks=None, retailer_ids=None):
     df["new_units"] = df["units"] * own_factor * cross_factor
     df["new_revenue"] = df["new_units"] * df["new_price"]
     df["margin"] = (df["new_price"] - df["cost_per_unit"]) * df["new_units"]
+    df["base_revenue"] = df["net_price"] * df["units"]
+    df["base_margin"] = (df["net_price"] - df["cost_per_unit"]) * df["units"]
 
     agg = (
         df.groupby(["week"])
-        .agg(units=("new_units", "sum"), revenue=("new_revenue", "sum"), margin=("margin", "sum"))
+        .agg(
+            units=("new_units", "sum"),
+            revenue=("new_revenue", "sum"),
+            margin=("margin", "sum"),
+            base_units=("units", "sum"),
+            base_revenue=("base_revenue", "sum"),
+            base_margin=("base_margin", "sum"),
+        )
         .reset_index()
     )
     return agg, df


### PR DESCRIPTION
## Summary
- add baseline revenue, margin, and unit tracking to price change simulations
- compute KPI deltas against baseline averages so zero price moves yield zero impact

## Testing
- pytest backend

------
https://chatgpt.com/codex/tasks/task_e_68df78a7d56c83309bea9447057c14af