### PR TITLE
Invalidate cached simulator and optimizer tables after data refresh

### DIFF
--- a/backend/app/models/cache.py
+++ b/backend/app/models/cache.py
@@ -1,0 +1,36 @@
+"""Utilities for managing cached model data structures."""
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Callable
+
+
+def _clear_cache(func: Callable[[], object]) -> None:
+    """Clear an ``functools.lru_cache`` decorated function if possible."""
+    cache_clear = getattr(func, "cache_clear", None)
+    if callable(cache_clear):
+        cache_clear()  # type: ignore[call-arg]
+
+
+def invalidate_model_caches() -> None:
+    """Reset cached simulator/optimizer tables after data refresh.
+
+    Price simulations and the optimizer both memoize expensive table loads to
+    keep interactive requests fast.  Whenever we regenerate synthetic data or
+    retrain elasticities those caches must be purged so fresh numbers are
+    returned.  Previously the caches stayed warm forever which meant the API
+    served stale weeks/SKU counts after data refreshes.  Clearing them ensures
+    the simulator and optimizer always operate on the latest tables.
+    """
+
+    with suppress(ImportError):
+        from . import simulator, optimizer
+
+        for func in (
+            simulator._load,
+            simulator._price_simulation_frame,
+            simulator._delist_frame,
+            optimizer._load_tables,
+        ):
+            _clear_cache(func)
+

--- a/backend/app/models/elasticities.py
+++ b/backend/app/models/elasticities.py
@@ -62,4 +62,10 @@ def fit_elasticities():
 
     write_table(pd.DataFrame(elast_rows), "elasticities")
     write_table(pd.DataFrame(imp_rows), "attributes_importance")
+
+    # Elasticities feed both the simulator and optimizer; clear cached tables so
+    # subsequent requests recompute with the freshly trained coefficients.
+    from .cache import invalidate_model_caches
+
+    invalidate_model_caches()
     return True

--- a/backend/app/synth_data.py
+++ b/backend/app/synth_data.py
@@ -237,6 +237,12 @@ def gen_weekly_data(
         write_table(df, name)
         to_parquet(df, name)
 
+    # Refresh memoized tables used by simulators/optimizer so downstream API
+    # calls immediately reflect the newly generated dataset.
+    from .models.cache import invalidate_model_caches
+
+    invalidate_model_caches()
+
     return True
 
 

--- a/backend/tests/test_model_cache_refresh.py
+++ b/backend/tests/test_model_cache_refresh.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from app.bootstrap import bootstrap_if_needed
+from app.models.optimizer import run_optimizer
+from app.models.simulator import simulate_price_change
+from app.models.elasticities import fit_elasticities
+from app.synth_data import gen_weekly_data
+from app.utils.io import engine
+
+
+def test_simulator_optimizer_use_fresh_data():
+    """Regenerating data should invalidate cached simulator/optimizer tables."""
+
+    bootstrap_if_needed()
+
+    # Warm caches so the test fails without invalidation logic.
+    simulate_price_change({})
+    run_optimizer()
+
+    try:
+        # Generate a much smaller dataset and retrain elasticities so the new
+        # tables clearly differ from the cached versions.
+        gen_weekly_data(weeks=3, n_per_brand=1, retailers_per_combo=1)
+        fit_elasticities()
+
+        _agg_after, rows_after = simulate_price_change({})
+        assert int(rows_after["week"].max()) == 3
+
+        solution_after, _kpis_after = run_optimizer()
+        with engine().connect() as con:
+            expected_skus = pd.read_sql("select sku_id from guardrails", con)
+        assert len(solution_after) == len(expected_skus)
+    finally:
+        # Restore the default synthetic dataset for the remaining test suite.
+        gen_weekly_data()
+        fit_elasticities()
+


### PR DESCRIPTION
## Summary
- add a shared helper to clear cached simulator and optimizer tables
- invoke cache invalidation after generating synthetic data and fitting elasticities
- cover the behaviour with a regression test that regenerates a smaller dataset

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df7db3bbbc83308bc321578a888375