### PR TITLE
Improve resiliency of simulator, optimizer, and huddle

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,14 +13,17 @@ const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS) || 300000;
 // API_URL must be the Cloud Run URL of the FastAPI service (no trailing slash)
 const API_URL = process.env.API_URL;
 if (!API_URL) {
-  console.warn("WARNING: API_URL env var not set; /api proxy will use localhost:8080");
+  console.error(
+    "ERROR: API_URL env var is required; set it to your FastAPI service URL"
+  );
+  process.exit(1);
 }
 
 // Proxy /api -> FastAPI
 app.use(
   "/api",
   createProxyMiddleware({
-    target: API_URL || "http://localhost:8080",
+    target: API_URL,
     changeOrigin: true,
     xfwd: true,
     pathRewrite: { "^/api": "" },
@@ -42,9 +45,7 @@ app.use(express.static(DIST));
 app.get("*", (_, res) => res.sendFile(path.join(DIST, "index.html")));
 
 const port = process.env.PORT || 3000;
-app.listen(port, '0.0.0.0', () =>
-  console.log(
-    `UI listening on ${port}; API proxy -> ${API_URL || "http://localhost:8080"}`
-  )
+app.listen(port, "0.0.0.0", () =>
+  console.log(`UI listening on ${port}; API proxy -> ${API_URL}`)
 );
 

--- a/src/components/AgenticHuddle.tsx
+++ b/src/components/AgenticHuddle.tsx
@@ -64,9 +64,6 @@ export default function AgenticHuddle() {
   const [apiToken, setApiToken] = useState<string>(
     localStorage.getItem("API_TOKEN") || ""
   );
-  const [demoReady, setDemoReady] = useState(false);
-  // When a prompt tile triggers the huddle we auto-run a demo on failure
-  const [runDemoOnFail, setRunDemoOnFail] = useState(false);
   const [progress, setProgress] = useState<string[]>([]);
   const [progressMessages, setProgressMessages] = useState<string[]>([
     "Agentic collaborators syncing...",
@@ -142,16 +139,10 @@ export default function AgenticHuddle() {
         }
       }
       const errMsg = status ? `${status}: ${msg}` : msg;
-      if (runDemoOnFail) {
-        runDemo(false);
-        setError(`${errMsg} — showing demo results`);
-      } else {
-        setError(errMsg);
-        setDemoReady(true);
-      }
+      runDemo(false);
+      setError(`${errMsg} — showing demo results`);
     } finally {
       setLoading(false);
-      setRunDemoOnFail(false);
       setProgress([]);
     }
   };
@@ -221,7 +212,6 @@ export default function AgenticHuddle() {
   };
 
   const handleTileClick = (question: string) => {
-    setRunDemoOnFail(true);
     // Directly start the huddle with the clicked tile's question
     start(question);
   };
@@ -318,12 +308,9 @@ export default function AgenticHuddle() {
       </Card>
 
       {error && (
-        <Card className="p-4 bg-destructive/10 border-destructive/20 space-y-3">
+        <Card className="p-4 bg-destructive/10 border-destructive/20 space-y-2">
           <div className="text-destructive text-sm font-medium">{error}</div>
-          <div className="text-xs text-muted-foreground">API base: <span className="font-mono">{API_BASE}</span>. Check Advanced API settings above or try Demo.</div>
-          {demoReady && (
-            <button onClick={runDemo} className="px-3 py-2 rounded-md bg-primary text-primary-foreground w-fit">Run Demo Huddle</button>
-          )}
+          <div className="text-xs text-muted-foreground">API base: <span className="font-mono">{API_BASE}</span>. Adjust settings above or retry once the service is healthy.</div>
         </Card>
       )}
 


### PR DESCRIPTION
## Summary
- surface detailed error messages in the price simulator and keep the last successful run visible
- add optimizer error handling so previous recommendations remain available when the API blips
- auto-fallback to the demo transcript when agentic huddles fail and simplify the error banner messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e554b4f2008330bda6e5a5e49455f1